### PR TITLE
Remove non-essential dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="animalai",
-    version="3.0.4",
+    version="3.0.5",
     description="Animal AI 3 Python API",
-    long_description= open('README.md').read(),
-    long_description_content_type = 'text/markdown',
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     url="https://github.com/Kinds-of-Intelligence-CFI/animalai-package",
     author="Matt Crosby; Ibrahim Alhas; Konstantinos Voudouris; Wout Schellaert; Joel Holmes; Ben Beyret",
     author_email="kindsofintelligence.cfi@gmail.com",
@@ -21,23 +21,20 @@ setup(
         "Operating System :: Microsoft :: Windows :: Windows 10",
         "Operating System :: Microsoft :: Windows :: Windows 11",
         "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX :: Linux"
+        "Operating System :: POSIX :: Linux",
     ],
     project_urls={
         "Website": "https://sites.google.com/csah.cam.ac.uk/animalai",
         "Main Repository": "https://github.com/Kinds-of-Intelligence-CFI/animal-ai",
-        "Releases": "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/releases",#
-        "Documentation": "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/tree/main/docs"
+        "Releases": "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/releases",  #
+        "Documentation": "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/tree/main/docs",
     },
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     zip_safe=False,
-    install_requires=["mlagents==0.30.0",
-                      "numpy==1.21.2",
-                      "scipy==1.7.2",
-                      "pandas== 1.3.2",
-                      "protobuf== 3.20.3",
-                      "stable-baselines3== 2.1.0",
-                      "shimmy== 1.3.0",
-                      "notebook"],
+    install_requires=[
+        "mlagents==0.30.0",
+        "protobuf==3.20.3",
+        "numpy",
+    ],
     python_requires=">=3.6, <3.10",
 )


### PR DESCRIPTION
I'm not sure about protobuf, I assume its imported by ml-agents, but maybe the builds have specific versions? In that case we should document it. I left it in for now.

We need a numpy (any), as we currently use it ourselves (but not for anything complicated).

We of course need ml-agents.

We don't need any of the others right?

We need a gym (we use the spaces), but ml-agents provides the requirement, and it's a dangerous one to specify ourselves due to the big API changes.