### PR TITLE
Made Play.py directly runnable

### DIFF
--- a/animalai/play.py
+++ b/animalai/play.py
@@ -1,3 +1,4 @@
+import argparse
 import random
 
 from pathlib import Path
@@ -5,7 +6,7 @@ from pathlib import Path
 from animalai import AnimalAIEnvironment, arenas
 from animalai.executable import find_executable
 
-def play(configuration_file: str = None, env_path: str = None) -> None:
+def play(configuration_file: str = None, env_path: str = None, log_path: str = None) -> None:
     """
     Load a config file and play
     :param configuration_file: str path to a yaml configuration. Plays animalai.arenas.GoodGoal_Random.yml by default
@@ -19,6 +20,7 @@ def play(configuration_file: str = None, env_path: str = None) -> None:
         base_port=5005 + random.randint(0, 1000),
         arenas_configurations=configuration_file if configuration_file is not None else arenas.GOOD_GOAL_RANDOM_POS,
         play=True,
+        log_folder=log_path,
     )
 
     print("Press Q in the Unity window then Ctrl+C in the command line to close the environment effectively.")
@@ -31,3 +33,16 @@ def play(configuration_file: str = None, env_path: str = None) -> None:
         pass
     finally:
         environment.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='This file allows the user to open and play an AnimalAI environment.')
+    parser.add_argument("--AAI_path", default=None, type=str, help="The path to the AnimalAI binary to use.")
+    parser.add_argument("--config_path", default=None, type=str, help="The path to the config file of the environment you want ot use.")
+    parser.add_argument("--log_path", default="./logs", type=str, help="The folder AnimalAI should output its logs to.")
+
+    # parse the args
+    args = parser.parse_args()
+
+    # play in the ennvironment
+    play(configuration_file=args.config_path, env_path=args.AAI_path, log_path=args.log_path)


### PR DESCRIPTION
### PR Description

To make it easier for new and non-technical users to get started with AnimalAI users should be able to just call 
```bash
python -m animalai.play <args>
```
rather than having to setup and configure a jupyter notebook like is currently reccomended in the docs (https://github.com/Kinds-of-Intelligence-CFI/animal-ai/blob/main/docs/gettingStarted/Launching-AAI.md).

### Proposed change(s)

Changes play.py so that when ran directly it parses any commandline arguments for config_path and AAI_path. These are then used to call play().

We should also update the launchingAAI and getting started documents so that they mention this easier approach.

### Useful links (Github issues, discussion threads, etc.)

_i.e. fixed issue #999._

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
