### PR TITLE
added additional args

### DIFF
--- a/animalai/environment.py
+++ b/animalai/environment.py
@@ -57,7 +57,7 @@ class AnimalAIEnvironment(UnityEnvironment):
         Parameters
         ----------
         additional_args : List[str]
-            Currently not supported anymore. TODO.
+            Additional commandline arguments passed through to the unity executeable. Often useful for forcing GPU rendering using "-force-vulkan".
         log_folder : str
             Optional folder to write the Unity Player log file into. Requires absolute path.
         file_name : Optional[str]
@@ -153,7 +153,7 @@ class AnimalAIEnvironment(UnityEnvironment):
             seed=seed,
             no_graphics=no_graphics,
             timeout_wait=self.timeout,
-            additional_args=args,
+            additional_args=args + (additional_args or []),
             side_channels=self.side_channels,
             log_folder=log_folder,
         )

--- a/animalai/environment.py
+++ b/animalai/environment.py
@@ -58,6 +58,8 @@ class AnimalAIEnvironment(UnityEnvironment):
         ----------
         additional_args : List[str]
             Additional commandline arguments passed through to the unity executeable. Often useful for forcing GPU rendering using "-force-vulkan".
+            WARNING: This has not been tested extensively and was probably removed for a reason but that reason is not known.
+            Use at your own risk.
         log_folder : str
             Optional folder to write the Unity Player log file into. Requires absolute path.
         file_name : Optional[str]
@@ -145,6 +147,9 @@ class AnimalAIEnvironment(UnityEnvironment):
         self.targetFrameRate = targetFrameRate
 
         self.configure_side_channels(self.side_channels)
+
+        if additional_args is not None:
+            print(f"WARNING: additional_args is not fully tested and may cause issues. use at your own risk.\n{additional_args}")
 
         super().__init__(
             file_name=file_name,


### PR DESCRIPTION
Added the option to pass the additional args through to unity. This probably isn't the best solution but for now it should be fine.

### PR Description

On linux (and probably on other platforms) AAI doesnt not currently default to using the GPU for rendering visual observations making the environment run slower especially at higher timescales. Adding the option to pass your own commandline arguments can solve this and potentially other issues.

### Proposed change(s)

Takes the `additional_args` argument that is currently unused and appends it to the variable args before sending them as arguments to the unity executeable. Comments suggest that `additional_args` is no longer used for a specific reason however, I can't find that reason.

### Useful links (Github issues, discussion threads, etc.)

N/A

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
