### PR TITLE
switch loading to use filenames

### DIFF
--- a/animalai/download.py
+++ b/animalai/download.py
@@ -27,11 +27,11 @@ BINARY_NAMES = {
     "MacOS": "MacOS.app",
 }
 
-MOST_RECENT_VERSION = "v4.3.0"
+MOST_RECENT_VERSION = "v4.3.1"
 CHECKSUMS = {
-    "Windows": "sha256:be9c7bc1b620530446d69672701a510a1bd4fd55f6844d5becac3b5efd300a17",
-    "Linux": "sha256:64bc4f77aa5fe37e413ec5b09b7cbff06a752cace5eb9d65fee37878267d029f",
-    "MacOS": "sha256:16f576b9e0ecb5012ee126a8dc3fe818573080e307c5598fe013b1c5d4f0b842",
+    "Windows": "sha256:7b46302d8b7edc26be944840ad5430e44d71bcb6d65abe14cf900cea3388188e",
+    "Linux": "sha256:a30ee1af7a2a5bc38db4c570a273c772cc5ea390bbf3964f59caef7542e8c3e8",
+    "MacOS": "sha256:a0c305e0a93c521f9cad9768bb5d4697b8b476c052c5f29614e170b8b5ae3ac4",
 }
 
 class DownloadError(Exception):

--- a/animalai/environment.py
+++ b/animalai/environment.py
@@ -1,4 +1,5 @@
 import uuid
+import os
 from typing import NamedTuple, Dict, Optional, List
 from mlagents_envs.environment import UnityEnvironment
 from mlagents_envs.rpc_communicator import UnityTimeOutException
@@ -222,13 +223,17 @@ class AnimalAIEnvironment(UnityEnvironment):
 
     def reset(self, arenas_configurations="") -> None:
         if arenas_configurations != "":
-            f = open(arenas_configurations, "r")
-            d = f.read()
-            f.close()
+            if os.path.exists(arenas_configurations):
+                absolute_path = os.path.abspath(arenas_configurations)
+            else:
+                raise FileNotFoundError(
+                    f"File {arenas_configurations} does not exist. "
+                    "Please provide a valid path to the arenas configuration file."
+                )
             side_channel = self.arenas_parameters_side_channel
             if side_channel is None:
                 raise RuntimeError("Arenas parameters side channel not found. ")
-            side_channel.send_raw_data(bytearray(d, encoding="utf-8"))
+            side_channel.send_raw_data(bytearray(absolute_path, encoding="utf-8"))
         try:
             super().reset()
         except UnityTimeOutException as timeoutException:


### PR DESCRIPTION
### PR Description

loading large configs can be slow due to needing to send the full content of the file. this change makes it so that only the file path to the config is sent and the unity side will load the file content itself.

### Proposed change(s)

modifies the reset method to just send the path to the config file rather than the content.

### Useful links (Github issues, discussion threads, etc.)

PR for the unity side that receives this change.
https://github.com/Kinds-of-Intelligence-CFI/animal-ai-unity/pull/49

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
