### PR TITLE
Download AnimalAI binaries automatically

### DIFF
--- a/animalai/__init__.py
+++ b/animalai/__init__.py
@@ -1,11 +1,10 @@
 from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _get_version
 
-from animalai.download import download_binary as download_binary
+from animalai.download import download_binary as download_binary, get_package_version
 from animalai.environment import AnimalAIEnvironment as AnimalAIEnvironment
 from animalai import arenas as arenas
 
 try:
-    __version__ = _get_version("animalai")
+    __version__ = get_package_version()
 except PackageNotFoundError:
     __version__ = "0.0.0-dev"

--- a/animalai/__init__.py
+++ b/animalai/__init__.py
@@ -1,2 +1,11 @@
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _get_version
+
+from animalai.download import download_binary as download_binary
 from animalai.environment import AnimalAIEnvironment as AnimalAIEnvironment
 from animalai import arenas as arenas
+
+try:
+    __version__ = _get_version("animalai")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/animalai/__main__.py
+++ b/animalai/__main__.py
@@ -1,0 +1,108 @@
+"""CLI entry point for animalai: python -m animalai <command>"""
+
+import argparse
+import sys
+
+from animalai.download import (
+    DownloadError,
+    cleanup_old_versions,
+    download_binary,
+    get_cache_info,
+)
+
+
+def cmd_download(args):
+    try:
+        path = download_binary(
+            ver=args.version, platform=args.platform, force=args.force
+        )
+        print(f"Binary ready at: {path}")
+    except DownloadError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_info(args):
+    info = get_cache_info()
+    print(f"Animal-AI v{info['version']}")
+    print(f"Cache directory: {info['cache_dir']}")
+
+    if not info["versions"]:
+        print("No cached binaries.")
+    else:
+        print("Cached versions:")
+        for v in info["versions"]:
+            status = "complete" if v["complete"] else "incomplete"
+            platforms = ", ".join(v["platforms"]) if v["platforms"] else "none"
+            print(
+                f"  {v['version']} [{status}] - {platforms} ({v['size_mb']:.1f} MB)"
+            )
+    return 0
+
+
+def cmd_cleanup(args):
+    removed = cleanup_old_versions(keep_current=not args.all)
+    if removed:
+        for v in removed:
+            print(f"Removed v{v}")
+        print(f"Cleaned up {len(removed)} version(s).")
+    else:
+        print("Nothing to clean up.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="animalai", description="Animal-AI command-line tools"
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    dl_parser = subparsers.add_parser(
+        "download", help="Download the AAI Unity binary"
+    )
+    dl_parser.add_argument(
+        "--version",
+        default=None,
+        help="Version to download (default: current package version)",
+    )
+    dl_parser.add_argument(
+        "--platform",
+        default=None,
+        choices=["Linux", "Windows", "MacOS"],
+        help="Platform to download for (default: auto-detect)",
+    )
+    dl_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download even if already cached",
+    )
+
+    subparsers.add_parser("info", help="Show cache and version info")
+
+    clean_parser = subparsers.add_parser(
+        "cleanup", help="Remove old cached versions"
+    )
+    clean_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Remove all cached versions including current",
+    )
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    handlers = {
+        "download": cmd_download,
+        "info": cmd_info,
+        "cleanup": cmd_cleanup,
+    }
+
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -113,8 +113,7 @@ def download_file(url: str, dest: Path, timeout: int = 30) -> None:
         if attempt > 0:
             delay = RETRY_BASE_DELAY ** attempt
             print(
-                f"  Retry {attempt}/{MAX_RETRIES - 1} after {delay}s...",
-                file=sys.stderr,
+                f"  Retry {attempt}/{MAX_RETRIES - 1} after {delay}s..."
             )
             time.sleep(delay)
 
@@ -132,16 +131,15 @@ def download_file(url: str, dest: Path, timeout: int = 30) -> None:
                             break
                         f.write(chunk)
                         downloaded += len(chunk)
-                        if sys.stderr.isatty():
+                        if sys.stdout.isatty():
                             print(
                                 _progress_bar(downloaded, total_size),
                                 end="",
-                                file=sys.stderr,
                                 flush=True,
                             )
 
-                if sys.stderr.isatty():
-                    print(file=sys.stderr)
+                if sys.stdout.isatty():
+                    print(file=sys.stdout)
                 return
 
         except (HTTPError, URLError, TimeoutError, OSError) as e:
@@ -250,12 +248,11 @@ def download_binary(
     if complete_marker.exists() and platform_dir.exists() and not force:
         cached = find_cached_executable(ver)
         if cached is not None:
-            print(f"Binary already cached at {platform_dir}", file=sys.stderr)
+            print(f"Binary already cached at {platform_dir}")
             return cached
         # .complete exists but binary not found -- re-download
         print(
-            "Cache marker exists but binary not found. Re-downloading...",
-            file=sys.stderr,
+            "Cache marker exists but binary not found. Re-downloading..."
         )
 
     if force and platform_dir.exists():
@@ -269,7 +266,6 @@ def download_binary(
     with _download_lock(version_dir):
         print(
             f"Downloading {archive_name} from GitHub Releases...",
-            file=sys.stderr,
         )
         try:
             download_file(archive_url, archive_path)
@@ -300,7 +296,7 @@ def download_binary(
             f"Expected one of: {', '.join(BINARY_NAMES.values())}"
         )
 
-    print(f"Done. Binary at: {executable}", file=sys.stderr)
+    print(f"Done. Binary at: {executable}")
     return executable
 
 

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -1,6 +1,5 @@
 """Download and cache Animal-AI Unity binaries from GitHub Releases."""
 
-import hashlib
 import os
 import shutil
 import stat
@@ -242,7 +241,7 @@ def download_binary(
 
     cache_dir = get_cache_dir()
     version_dir = cache_dir / "envs" / ver
-    platform_dir = version_dir # needs to be one level higher as the zip file contains a folder with the platform name in it
+    platform_dir = version_dir / platform
     complete_marker = version_dir / ".complete"
 
     # Already downloaded?
@@ -281,8 +280,8 @@ def download_binary(
         # should probably add a checeksum test here but it seems abit pointless to do if we're just gonna host them on github aswell 
 
         # Extract
-        print(f"Extracting to {platform_dir}...", file=sys.stderr)
-        extract_archive(archive_path, platform_dir)
+        print(f"Extracting to {version_dir}...")
+        extract_archive(archive_path, version_dir)
 
         # Clean up archive
         archive_path.unlink(missing_ok=True)

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -57,7 +57,7 @@ def get_package_version() -> str:
             "Could not determine animalai package version. "
         )
 
-def get_binary_vesion() -> str:
+def get_binary_version() -> str:
     try:
         return VERSION_MAP[get_package_version()]
     except KeyError:
@@ -201,7 +201,7 @@ def find_cached_executable(ver: str | None = None) -> Path | None:
     """Look for an already-downloaded binary in the cache directory."""
     if ver is None:
         try:
-            ver = get_binary_vesion()
+            ver = get_binary_version()
         except DownloadError:
             return None
 
@@ -237,7 +237,7 @@ def download_binary(
     Returns the path to the platform directory containing the extracted binary.
     """
     if ver is None:
-        ver = get_binary_vesion()
+        ver = get_binary_version()
     if platform is None:
         platform = get_current_platform()
 
@@ -312,7 +312,7 @@ def cleanup_old_versions(keep_current: bool = True) -> list[str]:
         return []
 
     try:
-        current_version = get_binary_vesion() if keep_current else None
+        current_version = get_binary_version() if keep_current else None
     except DownloadError:
         current_version = None
 

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -25,10 +25,11 @@ BINARY_NAMES = {
     "MacOS": "MacOS.app",
 }
 
-# map the animal_ai-python versions to the animal_ai-unity versions are
+# map the animal_ai-python versions to the animal_ai-unity versions
 VERSION_MAP = {
     "6.0.0" : "v4.3.0"
 }
+MOST_RECENT_VERSION = "v4.3.0"
 
 
 class DownloadError(Exception):
@@ -61,8 +62,8 @@ def get_binary_version() -> str:
     try:
         return VERSION_MAP[get_package_version()]
     except KeyError:
-        print(f"Could not find specific version mapping for version {get_package_version()}, defaulting to identical mapping")
-        return get_package_version()
+        print(f"Could not find specific version mapping for version {get_package_version()}, defaulting to most recent version {MOST_RECENT_VERSION}")
+        return MOST_RECENT_VERSION
 
 def get_current_platform() -> str:
     platform_map = {
@@ -87,7 +88,7 @@ def _release_url(version: str, filename: str) -> str:
 
 
 def get_release_url(ver: str, platform: str) -> str:
-    archive = ARCHIVE_TEMPLATE.format(platform=platform, version=ver)
+    archive = ARCHIVE_TEMPLATE.format(platform=platform)
     return _release_url(ver, archive)
 
 

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -1,5 +1,6 @@
 """Download and cache Animal-AI Unity binaries from GitHub Releases."""
 
+import hashlib
 import os
 import shutil
 import stat
@@ -24,12 +25,12 @@ BINARY_NAMES = {
     "MacOS": "MacOS.app",
 }
 
-# map the animal_ai-python versions to the animal_ai-unity versions
-VERSION_MAP = {
-    "6.0.0" : "v4.3.0"
-}
 MOST_RECENT_VERSION = "v4.3.0"
-
+CHECKSUMS = {
+    "Windows": "sha256:be9c7bc1b620530446d69672701a510a1bd4fd55f6844d5becac3b5efd300a17",
+    "Linux": "sha256:64bc4f77aa5fe37e413ec5b09b7cbff06a752cace5eb9d65fee37878267d029f",
+    "MacOS": "sha256:16f576b9e0ecb5012ee126a8dc3fe818573080e307c5598fe013b1c5d4f0b842",
+}
 
 class DownloadError(Exception):
     pass
@@ -58,11 +59,7 @@ def get_package_version() -> str:
         )
 
 def get_binary_version() -> str:
-    try:
-        return VERSION_MAP[get_package_version()]
-    except KeyError:
-        print(f"Could not find specific version mapping for version {get_package_version()}, defaulting to most recent version {MOST_RECENT_VERSION}")
-        return MOST_RECENT_VERSION
+    return MOST_RECENT_VERSION
 
 def get_current_platform() -> str:
     platform_map = {
@@ -151,6 +148,24 @@ def download_file(url: str, dest: Path, timeout: int = 30) -> None:
         f"Failed to download {url} after {MAX_RETRIES} attempts: {last_error}"
     )
 
+
+
+def verify_checksum(file_path: Path, expected: str) -> None:
+    """Verify a file's checksum against an expected 'algorithm:hex' string."""
+    algo, _, expected_digest = expected.partition(":")
+    if not expected_digest:
+        raise DownloadError(f"Invalid checksum format: {expected}")
+    h = hashlib.new(algo)
+    with open(file_path, "rb") as f:
+        while chunk := f.read(CHUNK_SIZE):
+            h.update(chunk)
+    actual_digest = h.hexdigest()
+    if actual_digest != expected_digest:
+        raise DownloadError(
+            f"Checksum mismatch for {file_path.name}:\n"
+            f"  expected: {expected}\n"
+            f"  actual:   {algo}:{actual_digest}"
+        )
 
 
 def extract_archive(archive_path: Path, dest_dir: Path) -> None:
@@ -277,7 +292,8 @@ def download_binary(
                 f"Extract it to: {platform_dir}"
             )
 
-        # should probably add a checeksum test here but it seems abit pointless to do if we're just gonna host them on github aswell 
+        print("Verifying checksum...")
+        verify_checksum(archive_path, CHECKSUMS[platform])
 
         # Extract
         print(f"Extracting to {version_dir}...")

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -1,0 +1,372 @@
+"""Download and cache Animal-AI Unity binaries from GitHub Releases."""
+
+import hashlib
+import os
+import shutil
+import stat
+import sys
+import time
+import zipfile
+from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+GITHUB_REPO = "Kinds-of-Intelligence-CFI/animal-ai"
+ARCHIVE_TEMPLATE = "{platform}.zip"
+CHUNK_SIZE = 65536
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 2
+
+BINARY_NAMES = {
+    "Linux": "animalAI.x86_64",
+    "Windows": "Animal-AI.exe",
+    "MacOS": "MacOS.app",
+}
+
+# map the animal_ai-python versions to the animal_ai-unity versions are
+VERSION_MAP = {
+    "6.0.0" : "v4.3.0"
+}
+
+
+class DownloadError(Exception):
+    pass
+
+
+class UnsupportedPlatformError(DownloadError):
+    pass
+
+
+def get_cache_dir() -> Path:
+    return Path(os.environ.get("ANIMALAI_CACHE", Path.home() / ".animalai"))
+
+
+def get_package_version() -> str:
+    try:
+        return version("animalai")
+    except PackageNotFoundError:
+        # Fallback for development installs
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        if pyproject.exists():
+            for line in pyproject.read_text().splitlines():
+                if line.strip().startswith("version"):
+                    return line.split("=")[1].strip().strip('"')
+        raise DownloadError(
+            "Could not determine animalai package version. "
+        )
+
+def get_binary_vesion() -> str:
+    try:
+        return VERSION_MAP[get_package_version()]
+    except KeyError:
+        print(f"Could not find specific version mapping for version {get_package_version()}, defaulting to identical mapping")
+        return get_package_version()
+
+def get_current_platform() -> str:
+    platform_map = {
+        "linux": "Linux",
+        "win32": "Windows",
+        "darwin": "MacOS",
+    }
+    platform = platform_map.get(sys.platform)
+    if platform is None:
+        raise UnsupportedPlatformError(
+            f"Unsupported platform: {sys.platform}. "
+            f"Supported platforms: {', '.join(platform_map.values())}"
+        )
+    return platform
+
+
+def _release_url(version: str, filename: str) -> str:
+    return (
+        f"https://github.com/{GITHUB_REPO}/releases/download/"
+        f"{version}/{filename}"
+    )
+
+
+def get_release_url(ver: str, platform: str) -> str:
+    archive = ARCHIVE_TEMPLATE.format(platform=platform, version=ver)
+    return _release_url(ver, archive)
+
+
+def _progress_bar(current: int, total: int | None, width: int = 40) -> str:
+    if total and total > 0:
+        fraction = current / total
+        filled = int(width * fraction)
+        bar = "#" * filled + "-" * (width - filled)
+        mb_current = current / (1024 * 1024)
+        mb_total = total / (1024 * 1024)
+        return f"\r  [{bar}] {mb_current:.1f}/{mb_total:.1f} MB ({fraction:.0%})"
+    else:
+        mb_current = current / (1024 * 1024)
+        return f"\r  Downloaded {mb_current:.1f} MB..."
+
+
+def download_file(url: str, dest: Path, timeout: int = 30) -> None:
+    """Download a file with retries and progress display."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        if attempt > 0:
+            delay = RETRY_BASE_DELAY ** attempt
+            print(
+                f"  Retry {attempt}/{MAX_RETRIES - 1} after {delay}s...",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+        try:
+            req = Request(url, headers={"User-Agent": "animalai-python"})
+            with urlopen(req, timeout=timeout) as response:
+                total = response.headers.get("Content-Length")
+                total_size = int(total) if total else None
+
+                with open(dest, "wb") as f:
+                    downloaded = 0
+                    while True:
+                        chunk = response.read(CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if sys.stderr.isatty():
+                            print(
+                                _progress_bar(downloaded, total_size),
+                                end="",
+                                file=sys.stderr,
+                                flush=True,
+                            )
+
+                if sys.stderr.isatty():
+                    print(file=sys.stderr)
+                return
+
+        except (HTTPError, URLError, TimeoutError, OSError) as e:
+            last_error = e
+            if dest.exists():
+                dest.unlink()
+
+    raise DownloadError(
+        f"Failed to download {url} after {MAX_RETRIES} attempts: {last_error}"
+    )
+
+
+
+def extract_archive(archive_path: Path, dest_dir: Path) -> None:
+    """Extract a ZIP archive and set executable permissions on Linux/macOS."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        zf.extractall(dest_dir)
+
+    if sys.platform != "win32":
+        # Set executable permissions on binaries
+        for item in dest_dir.rglob("*"):
+            if item.is_file() and (
+                item.suffix in (".x86_64", ".so", "")
+                or item.name.endswith(".app")
+                or "MacOS" in str(item)
+            ):
+                item.chmod(item.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@contextmanager
+def _download_lock(version_dir: Path):
+    """Simple PID-based lockfile to prevent concurrent downloads."""
+    lock_path = version_dir / ".download_lock"
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    # Check for stale lock
+    if lock_path.exists():
+        try:
+            pid = int(lock_path.read_text().strip())
+            os.kill(pid, 0)  # Check if process is alive
+            raise DownloadError(
+                f"Another download is in progress (PID {pid}). "
+                f"If this is wrong, delete {lock_path}"
+            )
+        except (ValueError, ProcessLookupError, PermissionError):
+            lock_path.unlink(missing_ok=True)
+
+    lock_path.write_text(str(os.getpid()))
+    try:
+        yield
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+def find_cached_executable(ver: str | None = None) -> Path | None:
+    """Look for an already-downloaded binary in the cache directory."""
+    if ver is None:
+        try:
+            ver = get_binary_vesion()
+        except DownloadError:
+            return None
+
+    platform = get_current_platform()
+    cache_dir = get_cache_dir()
+    version_dir = cache_dir / "envs" / ver
+
+    # Must have .complete marker
+    if not (version_dir / ".complete").exists():
+        return None
+
+    platform_dir = version_dir / platform
+    if not platform_dir.exists():
+        return None
+
+    # Search using same patterns as find_executable
+    for bin_name in ["AAI", "AnimalAI", "animalAI", "Animal-AI", "MacOS"]:
+        for ext in ["x86_64", "exe", "app"]:
+            matches = list(platform_dir.glob(f"{bin_name}.{ext}"))
+            if matches:
+                return matches[0]
+
+    return None
+
+
+def download_binary(
+    ver: str | None = None,
+    platform: str | None = None,
+    force: bool = False,
+) -> Path:
+    """Download the AAI binary for the given version and platform.
+
+    Returns the path to the platform directory containing the extracted binary.
+    """
+    if ver is None:
+        ver = get_binary_vesion()
+    if platform is None:
+        platform = get_current_platform()
+
+    cache_dir = get_cache_dir()
+    version_dir = cache_dir / "envs" / ver
+    platform_dir = version_dir # needs to be one level higher as the zip file contains a folder with the platform name in it
+    complete_marker = version_dir / ".complete"
+
+    # Already downloaded?
+    if complete_marker.exists() and platform_dir.exists() and not force:
+        cached = find_cached_executable(ver)
+        if cached is not None:
+            print(f"Binary already cached at {platform_dir}", file=sys.stderr)
+            return cached
+        # .complete exists but binary not found -- re-download
+        print(
+            "Cache marker exists but binary not found. Re-downloading...",
+            file=sys.stderr,
+        )
+
+    if force and platform_dir.exists():
+        shutil.rmtree(platform_dir)
+        complete_marker.unlink(missing_ok=True)
+
+    archive_name = ARCHIVE_TEMPLATE.format(platform=platform, version=ver)
+    archive_url = get_release_url(ver, platform)
+    archive_path = version_dir / archive_name
+
+    with _download_lock(version_dir):
+        print(
+            f"Downloading {archive_name} from GitHub Releases...",
+            file=sys.stderr,
+        )
+        try:
+            download_file(archive_url, archive_path)
+        except DownloadError:
+            raise DownloadError(
+                f"Failed to download AAI binary.\n"
+                f"You can download it manually from:\n"
+                f"  {archive_url}\n"
+                f"Extract it to: {platform_dir}"
+            )
+
+        # should probably add a checeksum test here but it seems abit pointless to do if we're just gonna host them on github aswell 
+
+        # Extract
+        print(f"Extracting to {platform_dir}...", file=sys.stderr)
+        extract_archive(archive_path, platform_dir)
+
+        # Clean up archive
+        archive_path.unlink(missing_ok=True)
+
+        # Mark complete
+        complete_marker.touch()
+
+    executable = find_cached_executable(ver)
+    if executable is None:
+        raise DownloadError(
+            f"Extraction succeeded but could not find executable in {platform_dir}. "
+            f"Expected one of: {', '.join(BINARY_NAMES.values())}"
+        )
+
+    print(f"Done. Binary at: {executable}", file=sys.stderr)
+    return executable
+
+
+def cleanup_old_versions(keep_current: bool = True) -> list[str]:
+    """Remove old cached versions. Returns list of removed version strings."""
+    cache_dir = get_cache_dir()
+    envs_dir = cache_dir / "envs"
+    if not envs_dir.exists():
+        return []
+
+    try:
+        current_version = get_binary_vesion() if keep_current else None
+    except DownloadError:
+        current_version = None
+
+    removed = []
+    for version_dir in envs_dir.iterdir():
+        if not version_dir.is_dir():
+            continue
+        if keep_current and version_dir.name == current_version:
+            continue
+        shutil.rmtree(version_dir)
+        removed.append(version_dir.name)
+
+    return removed
+
+
+def get_cache_info() -> dict:
+    """Return information about the cache for display purposes."""
+    cache_dir = get_cache_dir()
+    envs_dir = cache_dir / "envs"
+
+    try:
+        pkg_version = get_package_version()
+    except DownloadError:
+        pkg_version = "unknown"
+
+    info = {
+        "version": pkg_version,
+        "cache_dir": str(cache_dir),
+        "versions": [],
+    }
+
+    if envs_dir.exists():
+        for version_dir in sorted(envs_dir.iterdir()):
+            if not version_dir.is_dir():
+                continue
+            complete = (version_dir / ".complete").exists()
+            platforms = [
+                p.name
+                for p in version_dir.iterdir()
+                if p.is_dir() and p.name in ("Linux", "Windows", "MacOS")
+            ]
+            # Calculate size
+            total_size = sum(
+                f.stat().st_size
+                for f in version_dir.rglob("*")
+                if f.is_file()
+            )
+            info["versions"].append(
+                {
+                    "version": version_dir.name,
+                    "complete": complete,
+                    "platforms": platforms,
+                    "size_mb": round(total_size / (1024 * 1024), 1),
+                }
+            )
+
+    return info

--- a/animalai/download.py
+++ b/animalai/download.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from tqdm import tqdm
+
 GITHUB_REPO = "Kinds-of-Intelligence-CFI/animal-ai"
 ARCHIVE_TEMPLATE = "{platform}.zip"
 CHUNK_SIZE = 65536
@@ -88,19 +90,6 @@ def get_release_url(ver: str, platform: str) -> str:
     return _release_url(ver, archive)
 
 
-def _progress_bar(current: int, total: int | None, width: int = 40) -> str:
-    if total and total > 0:
-        fraction = current / total
-        filled = int(width * fraction)
-        bar = "#" * filled + "-" * (width - filled)
-        mb_current = current / (1024 * 1024)
-        mb_total = total / (1024 * 1024)
-        return f"\r  [{bar}] {mb_current:.1f}/{mb_total:.1f} MB ({fraction:.0%})"
-    else:
-        mb_current = current / (1024 * 1024)
-        return f"\r  Downloaded {mb_current:.1f} MB..."
-
-
 def download_file(url: str, dest: Path, timeout: int = 30) -> None:
     """Download a file with retries and progress display."""
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -120,23 +109,15 @@ def download_file(url: str, dest: Path, timeout: int = 30) -> None:
                 total = response.headers.get("Content-Length")
                 total_size = int(total) if total else None
 
-                with open(dest, "wb") as f:
-                    downloaded = 0
-                    while True:
-                        chunk = response.read(CHUNK_SIZE)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-                        downloaded += len(chunk)
-                        if sys.stdout.isatty():
-                            print(
-                                _progress_bar(downloaded, total_size),
-                                end="",
-                                flush=True,
-                            )
+                with tqdm(total=total_size, unit="B", unit_scale=True) as pbar:
+                    with open(dest, "wb") as f:
+                        while True:
+                            chunk = response.read(CHUNK_SIZE)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                            pbar.update(len(chunk))
 
-                if sys.stdout.isatty():
-                    print(file=sys.stdout)
                 return
 
         except (HTTPError, URLError, TimeoutError, OSError) as e:

--- a/animalai/environment.py
+++ b/animalai/environment.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import uuid
 from typing import NamedTuple, Dict, Optional, List
 from mlagents_envs.environment import UnityEnvironment
@@ -8,6 +9,8 @@ from mlagents_envs.side_channel.engine_configuration_channel import (
     EngineConfig,
     EngineConfigurationChannel,
 )
+
+from animalai.executable import find_or_download_executable
 
 
 class PlayTrain(NamedTuple):
@@ -147,7 +150,7 @@ class AnimalAIEnvironment(UnityEnvironment):
         self.configure_side_channels(self.side_channels)
 
         super().__init__(
-            file_name=file_name,
+            file_name=file_name if file_name is not None else str(find_or_download_executable(base=Path(""))),
             worker_id=worker_id,
             base_port=base_port,
             seed=seed,

--- a/animalai/environment.py
+++ b/animalai/environment.py
@@ -150,7 +150,7 @@ class AnimalAIEnvironment(UnityEnvironment):
         self.configure_side_channels(self.side_channels)
 
         super().__init__(
-            file_name=file_name if file_name is not None else str(find_or_download_executable(base=Path(""))),
+            file_name=file_name or find_or_download_executable(),
             worker_id=worker_id,
             base_port=base_port,
             seed=seed,

--- a/animalai/executable.py
+++ b/animalai/executable.py
@@ -2,6 +2,14 @@ import os
 import sys
 from pathlib import Path
 
+from animalai.download import (
+    DownloadError,
+    download_binary,
+    find_cached_executable,
+    get_current_platform,
+    get_binary_version,
+)
+
 
 def find_executable(base: Path) -> Path:
     """
@@ -52,13 +60,6 @@ def find_or_download_executable(
     2. Cached download in ~/.animalai/
     3. Auto-download from GitHub Releases (if enabled)
     """
-    from animalai.download import (
-        DownloadError,
-        download_binary,
-        find_cached_executable,
-        get_current_platform,
-        get_binary_version,
-    )
 
     # 1. Try local directory
     if base is not None:

--- a/animalai/executable.py
+++ b/animalai/executable.py
@@ -57,8 +57,7 @@ def find_or_download_executable(
         download_binary,
         find_cached_executable,
         get_current_platform,
-        get_binary_vesion,
-        get_release_url,
+        get_binary_version,
     )
 
     # 1. Try local directory
@@ -95,7 +94,7 @@ def find_or_download_executable(
     # Prompt on TTY
     if sys.stderr.isatty():
         try:
-            ver = get_binary_vesion
+            ver = get_binary_version()
             platform = get_current_platform()
         except DownloadError as e:
             raise FileNotFoundError(str(e))

--- a/animalai/executable.py
+++ b/animalai/executable.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from pathlib import Path
 
 
@@ -29,7 +31,7 @@ def find_executable(base: Path) -> Path:
     # We brace expand manually because glob does not support it.
     binaries = [
         bin
-        for bin_name in ["AAI", "AnimalAI"]
+        for bin_name in ["AAI", "AnimalAI", "animalAI", "Animal-AI", "MacOS"]
         for ext in ["x86_64", "exe", "app"]
         for bin in env_folder.glob(f"{bin_name}.{ext}")
     ]
@@ -38,3 +40,78 @@ def find_executable(base: Path) -> Path:
         raise FileNotFoundError(f"{error_msg}\n\nReason: {reason}")
 
     return binaries[0]
+
+
+def find_or_download_executable(
+    base: Path | None = None, auto_download: bool = True
+) -> Path:
+    """Find the AAI binary locally, in cache, or by downloading it.
+
+    Search order:
+    1. Local directory (if base is provided)
+    2. Cached download in ~/.animalai/
+    3. Auto-download from GitHub Releases (if enabled)
+    """
+    from animalai.download import (
+        DownloadError,
+        download_binary,
+        find_cached_executable,
+        get_current_platform,
+        get_binary_vesion,
+        get_release_url,
+    )
+
+    # 1. Try local directory
+    if base is not None:
+        try:
+            return find_executable(base)
+        except FileNotFoundError:
+            pass
+
+    # 2. Try cache
+    cached = find_cached_executable()
+    if cached is not None:
+        return cached
+
+    # 3. Auto-download
+    auto_download_env = os.environ.get("ANIMALAI_AUTO_DOWNLOAD", "1").lower()
+    if auto_download_env in ("0", "false", "no"):
+        auto_download = False
+
+    ci_env = os.environ.get("CI", "").lower()
+    if ci_env in ("true", "1"):
+        auto_download = False
+
+    if not auto_download:
+        raise FileNotFoundError(
+            "Could not find any AAI environment binary.\n\n"
+            "Options:\n"
+            "  1. Download manually from https://github.com/Kinds-of-Intelligence-CFI/animal-ai/releases\n"
+            "  2. Run: python -m animalai download\n"
+            "  3. Pass the path directly via file_name parameter\n"
+            "  4. Place binaries in ./env/ directory"
+        )
+
+    # Prompt on TTY
+    if sys.stderr.isatty():
+        try:
+            ver = get_binary_vesion
+            platform = get_current_platform()
+        except DownloadError as e:
+            raise FileNotFoundError(str(e))
+
+        print(
+            f"No AAI binary found. About to download v{ver} for {platform} (~400MB).",
+            file=sys.stderr,
+        )
+        try:
+            response = input("Continue? [Y/n] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            raise FileNotFoundError("Download cancelled.")
+        if response in ("n", "no"):
+            raise FileNotFoundError(
+                "Download cancelled. Run 'python -m animalai download' later."
+            )
+
+    return download_binary()

--- a/animalai/executable.py
+++ b/animalai/executable.py
@@ -51,8 +51,8 @@ def find_executable(base: Path) -> Path:
 
 
 def find_or_download_executable(
-    base: Path | None = None, auto_download: bool = True
-) -> Path:
+    base: Path = Path(""), auto_download: bool = True
+) -> str:
     """Find the AAI binary locally, in cache, or by downloading it.
 
     Search order:
@@ -62,16 +62,15 @@ def find_or_download_executable(
     """
 
     # 1. Try local directory
-    if base is not None:
-        try:
-            return find_executable(base)
-        except FileNotFoundError:
-            pass
+    try:
+        return str(find_executable(base))
+    except FileNotFoundError:
+        pass
 
     # 2. Try cache
     cached = find_cached_executable()
     if cached is not None:
-        return cached
+        return str(cached)
 
     # 3. Auto-download
     auto_download_env = os.environ.get("ANIMALAI_AUTO_DOWNLOAD", "1").lower()
@@ -114,4 +113,4 @@ def find_or_download_executable(
                 "Download cancelled. Run 'python -m animalai download' later."
             )
 
-    return download_binary()
+    return str(download_binary())

--- a/animalai/play.py
+++ b/animalai/play.py
@@ -4,7 +4,7 @@ import random
 from pathlib import Path
 
 from animalai import AnimalAIEnvironment, arenas
-from animalai.executable import find_executable
+from animalai.executable import find_or_download_executable
 
 def play(configuration_file: str = None, env_path: str = None, log_path: str = None) -> None:
     """
@@ -16,7 +16,7 @@ def play(configuration_file: str = None, env_path: str = None, log_path: str = N
 
     print("Initializing AAI environment")
     environment = AnimalAIEnvironment(
-        file_name=env_path if env_path is not None else str(find_executable(Path(""))),
+        file_name=env_path if env_path is not None else str(find_or_download_executable(base=Path(""))),
         base_port=5005 + random.randint(0, 1000),
         arenas_configurations=configuration_file if configuration_file is not None else arenas.GOOD_GOAL_RANDOM_POS,
         play=True,

--- a/animalai/play.py
+++ b/animalai/play.py
@@ -16,7 +16,7 @@ def play(configuration_file: str = None, env_path: str = None, log_path: str = N
 
     print("Initializing AAI environment")
     environment = AnimalAIEnvironment(
-        file_name=env_path if env_path is not None else str(find_or_download_executable(base=Path(""))),
+        file_name=env_path or find_or_download_executable(),
         base_port=5005 + random.randint(0, 1000),
         arenas_configurations=configuration_file if configuration_file is not None else arenas.GOOD_GOAL_RANDOM_POS,
         play=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.14"
 dependencies = [
     "mlagents-envs-aai>=1.0.0",
     "numpy",
+    "tqdm>=4.67.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,11 @@ dependencies = [
 "Website"         = "https://animalai.org/"
 "Repository"      = "https://github.com/Kinds-of-Intelligence-CFI/animal-ai-python"
 "Main Repository" = "https://github.com/Kinds-of-Intelligence-CFI/animal-ai"
-"Releases"        = "https://https://github.com/Kinds-of-Intelligence-CFI/animal-ai/releases"
+"Releases"        = "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/releases"
 "Documentation"   = "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/tree/main/docs"
+
+[project.scripts]
+animalai = "animalai.__main__:main"
 
 [build-system]
 requires      = ["hatchling"]

--- a/tests/test-download.py
+++ b/tests/test-download.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 from animalai.download import (
     ARCHIVE_TEMPLATE,
-    VERSION_MAP,
     DownloadError,
     UnsupportedPlatformError,
     cleanup_old_versions,
@@ -25,6 +24,7 @@ from animalai.download import (
     get_package_version,
     get_binary_version,
     get_release_url,
+    verify_checksum,
 )
 
 
@@ -57,18 +57,6 @@ class TestGetPackageVersion(unittest.TestCase):
         result = get_package_version()
         self.assertRegex(result, r"\d+\.\d+\.\d+")
     
-    @patch("animalai.download.version")
-    def test_binary_version_mapping(self, mock_version):
-        known_version_string = "6.0.0"
-        mock_version.return_value = known_version_string
-        self.assertEqual(get_binary_version(), VERSION_MAP[known_version_string])
-
-    @patch("animalai.download.version")
-    def test_binary_fallback_mapping(self, mock_version):
-        # if no matching version foudn then default to equal mapping 
-        test_version_string = "EXAMPLE_TEST_VERSION"
-        mock_version.return_value = test_version_string
-        self.assertEqual(get_binary_version(), test_version_string)
 
 
 class TestGetCurrentPlatform(unittest.TestCase):
@@ -277,7 +265,7 @@ class TestCleanupOldVersions(unittest.TestCase):
             cache_dir = Path(tmpdir)
             envs_dir = cache_dir / "envs"
             (envs_dir / "5.0.0" / "Linux").mkdir(parents=True)
-            (envs_dir / VERSION_MAP["6.0.0"] / "Linux").mkdir(parents=True)
+            (envs_dir / get_binary_version() / "Linux").mkdir(parents=True)
 
             with patch("animalai.download.get_cache_dir", return_value=cache_dir):
                 with patch("animalai.download.get_package_version", return_value="6.0.0"):
@@ -285,7 +273,7 @@ class TestCleanupOldVersions(unittest.TestCase):
 
             self.assertEqual(removed, ["5.0.0"])
             self.assertFalse((envs_dir / "5.0.0").exists())
-            self.assertTrue((envs_dir / VERSION_MAP["6.0.0"]).exists())
+            self.assertTrue((envs_dir / get_binary_version()).exists())
 
     def test_removes_all_when_requested(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -326,6 +314,42 @@ class TestCacheInfo(unittest.TestCase):
             self.assertEqual(info["versions"][0]["version"], "6.0.0")
             self.assertTrue(info["versions"][0]["complete"])
             self.assertIn("Linux", info["versions"][0]["platforms"])
+
+
+class TestVerifyChecksum(unittest.TestCase):
+    def test_valid_checksum_passes(self):
+        data = b"hello world"
+        digest = hashlib.sha256(data).hexdigest()
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(data)
+            f.flush()
+            try:
+                verify_checksum(Path(f.name), f"sha256:{digest}")
+            finally:
+                os.unlink(f.name)
+
+    def test_mismatched_checksum_raises(self):
+        data = b"hello world"
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(data)
+            f.flush()
+            try:
+                with self.assertRaises(DownloadError) as ctx:
+                    verify_checksum(Path(f.name), "sha256:0000dead")
+                self.assertIn("Checksum mismatch", str(ctx.exception))
+            finally:
+                os.unlink(f.name)
+
+    def test_invalid_format_raises(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"data")
+            f.flush()
+            try:
+                with self.assertRaises(DownloadError) as ctx:
+                    verify_checksum(Path(f.name), "nocolon")
+                self.assertIn("Invalid checksum format", str(ctx.exception))
+            finally:
+                os.unlink(f.name)
 
 
 class TestLockFile(unittest.TestCase):

--- a/tests/test-download.py
+++ b/tests/test-download.py
@@ -23,7 +23,7 @@ from animalai.download import (
     get_cache_info,
     get_current_platform,
     get_package_version,
-    get_binary_vesion,
+    get_binary_version,
     get_release_url,
 )
 
@@ -61,14 +61,14 @@ class TestGetPackageVersion(unittest.TestCase):
     def test_binary_version_mapping(self, mock_version):
         known_version_string = "6.0.0"
         mock_version.return_value = known_version_string
-        self.assertEqual(get_binary_vesion(), VERSION_MAP[known_version_string])
+        self.assertEqual(get_binary_version(), VERSION_MAP[known_version_string])
 
     @patch("animalai.download.version")
     def test_binary_fallback_mapping(self, mock_version):
         # if no matching version foudn then default to equal mapping 
         test_version_string = "EXAMPLE_TEST_VERSION"
         mock_version.return_value = test_version_string
-        self.assertEqual(get_binary_vesion(), test_version_string)
+        self.assertEqual(get_binary_version(), test_version_string)
 
 
 class TestGetCurrentPlatform(unittest.TestCase):

--- a/tests/test-download.py
+++ b/tests/test-download.py
@@ -1,0 +1,363 @@
+"""Tests for the animalai.download module."""
+
+import hashlib
+import io
+import os
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from animalai.download import (
+    ARCHIVE_TEMPLATE,
+    VERSION_MAP,
+    DownloadError,
+    UnsupportedPlatformError,
+    cleanup_old_versions,
+    download_binary,
+    download_file,
+    extract_archive,
+    find_cached_executable,
+    get_cache_dir,
+    get_cache_info,
+    get_current_platform,
+    get_package_version,
+    get_binary_vesion,
+    get_release_url,
+)
+
+
+class TestGetCacheDir(unittest.TestCase):
+    def test_default_cache_dir(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ANIMALAI_CACHE", None)
+            result = get_cache_dir()
+            self.assertEqual(result, Path.home() / ".animalai")
+
+    def test_custom_cache_dir(self):
+        with patch.dict(os.environ, {"ANIMALAI_CACHE": "/tmp/custom-cache"}):
+            result = get_cache_dir()
+            self.assertEqual(result, Path("/tmp/custom-cache"))
+
+
+class TestGetPackageVersion(unittest.TestCase):
+    @patch("animalai.download.version")
+    def test_installed_package(self, mock_version):
+        mock_version.return_value = "6.0.0"
+        self.assertEqual(get_package_version(), "6.0.0")
+
+    @patch("animalai.download.version")
+    def test_fallback_to_pyproject(self, mock_version):
+        from importlib.metadata import PackageNotFoundError
+
+        mock_version.side_effect = PackageNotFoundError("animalai")
+        # Should fall back to reading pyproject.toml from the repo
+        # This works in dev because pyproject.toml exists relative to the module
+        result = get_package_version()
+        self.assertRegex(result, r"\d+\.\d+\.\d+")
+    
+    @patch("animalai.download.version")
+    def test_binary_version_mapping(self, mock_version):
+        known_version_string = "6.0.0"
+        mock_version.return_value = known_version_string
+        self.assertEqual(get_binary_vesion(), VERSION_MAP[known_version_string])
+
+    @patch("animalai.download.version")
+    def test_binary_fallback_mapping(self, mock_version):
+        # if no matching version foudn then default to equal mapping 
+        test_version_string = "EXAMPLE_TEST_VERSION"
+        mock_version.return_value = test_version_string
+        self.assertEqual(get_binary_vesion(), test_version_string)
+
+
+class TestGetCurrentPlatform(unittest.TestCase):
+    @patch("animalai.download.sys")
+    def test_linux(self, mock_sys):
+        mock_sys.platform = "linux"
+        self.assertEqual(get_current_platform(), "Linux")
+
+    @patch("animalai.download.sys")
+    def test_windows(self, mock_sys):
+        mock_sys.platform = "win32"
+        self.assertEqual(get_current_platform(), "Windows")
+
+    @patch("animalai.download.sys")
+    def test_macos(self, mock_sys):
+        mock_sys.platform = "darwin"
+        self.assertEqual(get_current_platform(), "MacOS")
+
+    @patch("animalai.download.sys")
+    def test_unsupported(self, mock_sys):
+        mock_sys.platform = "freebsd"
+        with self.assertRaises(UnsupportedPlatformError):
+            get_current_platform()
+
+
+class TestURLConstruction(unittest.TestCase):
+    def test_release_url(self):
+        url = get_release_url("v1.1.1", "Linux")
+        self.assertEqual(
+            url,
+            "https://github.com/Kinds-of-Intelligence-CFI/animal-ai/"
+            "releases/download/v1.1.1/Linux.zip",
+        )
+
+
+@patch("animalai.download.time.sleep", return_value=None)
+class TestDownloadFile(unittest.TestCase):
+    @patch("animalai.download.urlopen")
+    def test_successful_download(self, mock_urlopen, _mock_sleep):
+        data = b"fake binary content" * 100
+        mock_response = MagicMock()
+        mock_response.read.side_effect = [data, b""]
+        mock_response.headers = {"Content-Length": str(len(data))}
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "test.zip"
+            download_file("https://example.com/test.zip", dest)
+            self.assertTrue(dest.exists())
+            self.assertEqual(dest.read_bytes(), data)
+
+    @patch("animalai.download.urlopen")
+    def test_retry_on_failure(self, mock_urlopen, _mock_sleep):
+        from urllib.error import URLError
+
+        data = b"content after retry"
+        mock_response = MagicMock()
+        mock_response.read.side_effect = [data, b""]
+        mock_response.headers = {"Content-Length": str(len(data))}
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        # First call fails, second succeeds
+        mock_urlopen.side_effect = [
+            URLError("connection reset"),
+            mock_response,
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "test.zip"
+            download_file("https://example.com/test.zip", dest)
+            self.assertTrue(dest.exists())
+            self.assertEqual(mock_urlopen.call_count, 2)
+
+    @patch("animalai.download.urlopen")
+    def test_all_retries_exhausted(self, mock_urlopen, _mock_sleep):
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("persistent failure")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir) / "test.zip"
+            with self.assertRaises(DownloadError):
+                download_file("https://example.com/test.zip", dest)
+
+
+class TestExtractArchive(unittest.TestCase):
+    def _make_zip(self, files: dict[str, bytes]) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for name, content in files.items():
+                zf.writestr(name, content)
+        return buf.getvalue()
+
+    def test_extract_files(self):
+        zip_data = self._make_zip(
+            {
+                "animalAI.x86_64": b"fake binary",
+                "animalAI_Data/config.txt": b"config data",
+            }
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = Path(tmpdir) / "test.zip"
+            archive_path.write_bytes(zip_data)
+
+            dest = Path(tmpdir) / "extracted"
+            extract_archive(archive_path, dest)
+
+            self.assertTrue((dest / "animalAI.x86_64").exists())
+            self.assertTrue((dest / "animalAI_Data" / "config.txt").exists())
+            self.assertEqual(
+                (dest / "animalAI.x86_64").read_bytes(), b"fake binary"
+            )
+
+    @patch("animalai.download.sys")
+    def test_sets_executable_permissions_on_linux(self, mock_sys):
+        mock_sys.platform = "linux"
+        zip_data = self._make_zip({"animalAI.x86_64": b"fake binary"})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = Path(tmpdir) / "test.zip"
+            archive_path.write_bytes(zip_data)
+
+            dest = Path(tmpdir) / "extracted"
+            extract_archive(archive_path, dest)
+
+            binary = dest / "animalAI.x86_64"
+            mode = binary.stat().st_mode
+            self.assertTrue(mode & 0o111, "Binary should be executable")
+
+
+class TestFindCachedExecutable(unittest.TestCase):
+    def test_finds_cached_binary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            version_dir = cache_dir / "envs" / "6.0.0"
+            platform_dir = version_dir / "Linux"
+            platform_dir.mkdir(parents=True)
+            (version_dir / ".complete").touch()
+            (platform_dir / "animalAI.x86_64").write_bytes(b"binary")
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_current_platform", return_value="Linux"):
+                    result = find_cached_executable("6.0.0")
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result.name, "animalAI.x86_64")
+
+    def test_returns_none_without_complete_marker(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            platform_dir = cache_dir / "envs" / "6.0.0" / "Linux"
+            platform_dir.mkdir(parents=True)
+            (platform_dir / "animalAI.x86_64").write_bytes(b"binary")
+            # No .complete marker
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_current_platform", return_value="Linux"):
+                    result = find_cached_executable("6.0.0")
+                    self.assertIsNone(result)
+
+    def test_returns_none_when_not_cached(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_current_platform", return_value="Linux"):
+                    result = find_cached_executable("6.0.0")
+                    self.assertIsNone(result)
+
+    def test_finds_windows_binary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            version_dir = cache_dir / "envs" / "6.0.0"
+            platform_dir = version_dir / "Windows"
+            platform_dir.mkdir(parents=True)
+            (version_dir / ".complete").touch()
+            (platform_dir / "Animal-AI.exe").write_bytes(b"binary")
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_current_platform", return_value="Windows"):
+                    result = find_cached_executable("6.0.0")
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result.name, "Animal-AI.exe")
+
+    def test_finds_macos_binary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            version_dir = cache_dir / "envs" / "6.0.0"
+            platform_dir = version_dir / "MacOS"
+            platform_dir.mkdir(parents=True)
+            (version_dir / ".complete").touch()
+            (platform_dir / "MacOS.app").write_bytes(b"binary")
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_current_platform", return_value="MacOS"):
+                    result = find_cached_executable("6.0.0")
+                    self.assertIsNotNone(result)
+                    self.assertEqual(result.name, "MacOS.app")
+
+
+class TestCleanupOldVersions(unittest.TestCase):
+    def test_removes_old_versions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            envs_dir = cache_dir / "envs"
+            (envs_dir / "5.0.0" / "Linux").mkdir(parents=True)
+            (envs_dir / VERSION_MAP["6.0.0"] / "Linux").mkdir(parents=True)
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_package_version", return_value="6.0.0"):
+                    removed = cleanup_old_versions(keep_current=True)
+
+            self.assertEqual(removed, ["5.0.0"])
+            self.assertFalse((envs_dir / "5.0.0").exists())
+            self.assertTrue((envs_dir / VERSION_MAP["6.0.0"]).exists())
+
+    def test_removes_all_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            envs_dir = cache_dir / "envs"
+            (envs_dir / "5.0.0" / "Linux").mkdir(parents=True)
+            (envs_dir / "6.0.0" / "Linux").mkdir(parents=True)
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                removed = cleanup_old_versions(keep_current=False)
+
+            self.assertEqual(sorted(removed), ["5.0.0", "6.0.0"])
+
+    def test_empty_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                removed = cleanup_old_versions()
+            self.assertEqual(removed, [])
+
+
+class TestCacheInfo(unittest.TestCase):
+    def test_cache_info_with_versions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            version_dir = cache_dir / "envs" / "6.0.0"
+            platform_dir = version_dir / "Linux"
+            platform_dir.mkdir(parents=True)
+            (version_dir / ".complete").touch()
+            (platform_dir / "animalAI.x86_64").write_bytes(b"x" * 1024)
+
+            with patch("animalai.download.get_cache_dir", return_value=cache_dir):
+                with patch("animalai.download.get_package_version", return_value="6.0.0"):
+                    info = get_cache_info()
+
+            self.assertEqual(info["version"], "6.0.0")
+            self.assertEqual(len(info["versions"]), 1)
+            self.assertEqual(info["versions"][0]["version"], "6.0.0")
+            self.assertTrue(info["versions"][0]["complete"])
+            self.assertIn("Linux", info["versions"][0]["platforms"])
+
+
+class TestLockFile(unittest.TestCase):
+    def test_lock_acquired_and_released(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from animalai.download import _download_lock
+
+            version_dir = Path(tmpdir) / "6.0.0"
+            version_dir.mkdir()
+
+            lock_path = version_dir / ".download_lock"
+            with _download_lock(version_dir):
+                self.assertTrue(lock_path.exists())
+                self.assertEqual(lock_path.read_text().strip(), str(os.getpid()))
+
+            self.assertFalse(lock_path.exists())
+
+    def test_stale_lock_removed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from animalai.download import _download_lock
+
+            version_dir = Path(tmpdir) / "6.0.0"
+            version_dir.mkdir()
+
+            lock_path = version_dir / ".download_lock"
+            # Write a stale lock with a PID that doesn't exist
+            lock_path.write_text("999999999")
+
+            with _download_lock(version_dir):
+                self.assertTrue(lock_path.exists())
+                self.assertEqual(lock_path.read_text().strip(), str(os.getpid()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-environment.py
+++ b/tests/test-environment.py
@@ -21,7 +21,7 @@ class TestEnvironmentInitialization(unittest.TestCase):
     def test_initialization_with_custom_parameters(self, mock_env):
         """Test initialization with custom parameters."""
         env = AnimalAIEnvironment(
-            file_name="custom_file.yml", worker_id=2
+            arenas_configurations="custom_file.yml", worker_id=2
         )  # For custom file path, use full path.
         mock_env.assert_called_once()
         self.assertIsNotNone(env)

--- a/tests/test-manual-play.py
+++ b/tests/test-manual-play.py
@@ -12,7 +12,6 @@ class TestManualPlay(unittest.TestCase):
 
         # Initialize the AnimalAI environment from environment.py script
         env = AnimalAIEnvironment(
-            file_name='test/executable',
             base_port=5005 + random.randint(0, 1000),
             play=True,  # Here, we check if play mode is launched correctly
         )


### PR DESCRIPTION
### PR Description

It is really annoying to download the binaries for animal ai seperately and then to point the python side to the location each time. It would be really convenient if the binaries auto downloaded when the user when to run the environment.

### Proposed change(s)

Added the functionality to download the binaries for the current version of animal ai. This is automatically called if no path to an executable is given and no exisiting binary can be found. Additionally, there is a script included to manually download the binaries and clear out old ones.
```bash
python -m animalai download
python -m animalai cleanup
```
Finally, this PR includes some updates to the tests to make them use the new correct binaries rather than pointing to missing files and such. 

### Useful links (Github issues, discussion threads, etc.)

Doc update PR to go with these changes https://github.com/Kinds-of-Intelligence-CFI/animal-ai/pull/63

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
