### PR TITLE
Changed the format of the generic typing to support older versions

### DIFF
--- a/animalai/LLM_scaffolds/environment_scaffolds.py
+++ b/animalai/LLM_scaffolds/environment_scaffolds.py
@@ -1,14 +1,15 @@
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
 import numpy as np
 
 from animalai.environment import AnimalAIEnvironment
 from mlagents_envs.base_env import ActionTuple
 
+ObsType = TypeVar("ObsType")
 
 
-
-class EnvironmentScaffold[ObsType](ABC):
+class EnvironmentScaffold(ABC, Generic[ObsType]):
     """Abstract base class for environment scaffolds which handle converting actions from an llm (whatever the harness) into actions in AAI and return some results."""
     def __init__(self, env: AnimalAIEnvironment):
         self.env = env


### PR DESCRIPTION
### PR Description

Older versions of python do not support the formatting of generic types used in environment scaffold. This PR changes it to the older version to make it possible to use on older platforms.

### Proposed change(s)

changed the formatting of the generic typing of environment scaffold.

### Useful links (Github issues, discussion threads, etc.)

_i.e. fixed issue #999._

### Types of change(s)
- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
