### PR TITLE
fixed syntax error in example arenas

### DIFF
--- a/animalai/arenas/GoodGoal_Fixed.yml
+++ b/animalai/arenas/GoodGoal_Fixed.yml
@@ -2,7 +2,7 @@
 arenas:
   0: !Arena
     passMark: 1
-    timeLimit:500
+    timeLimit: 500
     items:
       - !Item
         name: Agent

--- a/animalai/arenas/GoodGoal_Random.yml
+++ b/animalai/arenas/GoodGoal_Random.yml
@@ -2,7 +2,7 @@
 arenas:
   0: !Arena
     passMark: 1
-    timeLimit:500
+    timeLimit: 500
     items:
       - !Item
         name: Agent


### PR DESCRIPTION
### PR Description

Existing example arenas had a syntax error in the yaml files.

### Proposed change(s)

Fixed syntax error by adding a space between `timelimit:500`

### Useful links (Github issues, discussion threads, etc.)

_i.e. fixed issue #999._

### Types of change(s)
- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
