### PR TITLE
Unity to x wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ For more information about the ways you can contribute to Animal-AI, visit our w
 If you are new to contributing to open source, [this](https://github.com/Kinds-of-Intelligence-CFI/animal-ai/blob/main/CONTRIBUTING.md) guide helps explain why, what, and how to successfully get involved.
 
 ## Version History
+* v6.1.3
+  + Added UnityToGymnasium and AnimalAIGymnasiumWrapper wrappers  
 * v6.1.2
   + Fixed the version string for the executable autodownload
   + Misc fixes to the inspect wrapper

--- a/animalai/LLM_scaffolds/environment_scaffolds.py
+++ b/animalai/LLM_scaffolds/environment_scaffolds.py
@@ -17,7 +17,7 @@ class EnvironmentScaffold(ABC, Generic[ObsType]):
 
     @abstractmethod
     def step(self, action: str) -> tuple[ObsType, float, bool, dict]:
-        """Takes an action and returns (obs, reward, done, info) following gym convention."""
+        """Takes an action and returns (obs, reward, done, info) following gymnasium convention."""
         raise NotImplementedError
 
     @abstractmethod

--- a/animalai/wrappers/__init__.py
+++ b/animalai/wrappers/__init__.py
@@ -1,0 +1,18 @@
+__all__ = [
+    "UnityToGymnasiumWrapper",
+    "UnityGymnasiumException",
+    "ActionFlattener",
+    "AnimalAIGymnasiumWrapper",
+]
+
+
+def __getattr__(name):
+    if name in ("UnityToGymnasiumWrapper", "UnityGymnasiumException", "ActionFlattener"):
+        from animalai.wrappers import unity_gymnasium
+
+        return getattr(unity_gymnasium, name)
+    if name == "AnimalAIGymnasiumWrapper":
+        from animalai.wrappers.animalai_gymnasium import AnimalAIGymnasiumWrapper
+
+        return AnimalAIGymnasiumWrapper
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/animalai/wrappers/animalai_gymnasium.py
+++ b/animalai/wrappers/animalai_gymnasium.py
@@ -20,65 +20,132 @@ class AnimalAIGymnasiumWrapper(UnityToGymnasiumWrapper):
     """Animal AI specific Gymnasium wrapper.
 
     Unlike the generic ``UnityToGymnasiumWrapper``, which returns a single
-    anonymous array, this wrapper returns a dictionary observation matching
-    ``AnimalAIEnvironment.get_obs_dict``. The keys present depend on the
-    environment's ``useCamera`` / ``useRayCasts`` flags; the intrinsic vector
-    (health, velocity, position) is always present.
+    anonymous array, this wrapper lets you pick which observation streams to
+    expose via the ``include_*`` flags. The available streams are ``camera``
+    and ``rays`` (only if the underlying ``AnimalAIEnvironment`` was created
+    with ``useCamera`` / ``useRayCasts``) plus the intrinsic vector, split into
+    the always-available ``health``, ``velocity`` and ``position``.
+
+    When more than one stream is selected the observation is a ``spaces.Dict``
+    keyed by stream name. When exactly one stream is selected the observation
+    collapses to that stream's bare ``Box`` (and ``reset`` / ``step`` return the
+    raw array), which is convenient for single-input policies such as
+    Stable-Baselines3's ``CnnPolicy``. Note that selecting ``health`` on its own
+    yields a scalar ``Box`` of shape ``()``.
+
+    The ``camera`` / ``rays`` flags default to ``None``, meaning "include if the
+    environment produces it"; setting one to ``True`` when the environment does
+    not produce that stream raises ``ValueError``. ``health`` / ``velocity`` /
+    ``position`` default to ``True``. The default construction therefore matches
+    the previous behaviour (full dict of every available stream).
 
     This is the recommended wrapper for Animal-AI. The wrapped ``unity_env``
     must be an ``AnimalAIEnvironment``.
     """
 
-    def __init__(self, unity_env: AnimalAIEnvironment, **kwargs):
+    def __init__(
+        self,
+        unity_env: AnimalAIEnvironment,
+        *,
+        include_camera: Optional[bool] = None,
+        include_rays: Optional[bool] = None,
+        include_health: bool = True,
+        include_velocity: bool = True,
+        include_position: bool = True,
+        **kwargs,
+    ):
         if not isinstance(unity_env, AnimalAIEnvironment):
             raise TypeError(
                 "AnimalAIGymnasiumWrapper requires an AnimalAIEnvironment. "
                 "Use UnityToGymnasiumWrapper for other Unity environments."
             )
-        self.useCamera = unity_env.useCamera
-        self.useRayCasts = unity_env.useRayCasts
+
+        # Whether the env actually produces these streams (drives spec order).
+        self._env_camera = unity_env.useCamera
+        self._env_rays = unity_env.useRayCasts
+
+        self.useCamera = self._resolve_stream(
+            include_camera, self._env_camera, "include_camera", "useCamera"
+        )
+        self.useRayCasts = self._resolve_stream(
+            include_rays, self._env_rays, "include_rays", "useRayCasts"
+        )
+
+        self._obs_keys: list = []
+        if self.useCamera:
+            self._obs_keys.append("camera")
+        if self.useRayCasts:
+            self._obs_keys.append("rays")
+        if include_health:
+            self._obs_keys.append("health")
+        if include_velocity:
+            self._obs_keys.append("velocity")
+        if include_position:
+            self._obs_keys.append("position")
+        if not self._obs_keys:
+            raise ValueError(
+                "At least one observation must be selected, but all include_* "
+                "flags resolved to False."
+            )
+        self._single_obs = len(self._obs_keys) == 1
+
         super().__init__(unity_env, **kwargs)
 
-    def _build_observation_space(self) -> spaces.Dict:
-        specs = self.group_spec.observation_specs
-        obs_spaces: dict = {}
-        idx = 0
-        if self.useCamera:
-            cam_shape = specs[idx].shape
-            if self.uint8_visual:
-                obs_spaces["camera"] = spaces.Box(
-                    0, 255, dtype=np.uint8, shape=cam_shape
-                )
-            else:
-                obs_spaces["camera"] = spaces.Box(
-                    0, 1, dtype=np.float32, shape=cam_shape
-                )
-            idx += 1
-        if self.useRayCasts:
-            ray_shape = specs[idx].shape
-            obs_spaces["rays"] = spaces.Box(
-                0, np.inf, dtype=np.float32, shape=ray_shape
+    @staticmethod
+    def _resolve_stream(flag, produced, flag_name, env_flag_name) -> bool:
+        if flag is None:
+            return produced
+        if flag and not produced:
+            raise ValueError(
+                f"{flag_name}=True but the environment was created with "
+                f"{env_flag_name}=False, so it produces no such observation."
             )
+        return bool(flag)
+
+    def _build_observation_space(self):
+        specs = self.group_spec.observation_specs
+        # Spec order follows what the env produces, not what we expose.
+        idx = 0
+        cam_shape = ray_shape = None
+        if self._env_camera:
+            cam_shape = specs[idx].shape
             idx += 1
-        # The intrinsic vector observation (size 7): [health, velocity(3), position(3)].
-        obs_spaces["health"] = spaces.Box(0, np.inf, dtype=np.float32, shape=())
-        obs_spaces["velocity"] = spaces.Box(
-            -np.inf, np.inf, dtype=np.float32, shape=(3,)
-        )
-        obs_spaces["position"] = spaces.Box(
-            -np.inf, np.inf, dtype=np.float32, shape=(3,)
-        )
+        if self._env_rays:
+            ray_shape = specs[idx].shape
+            idx += 1
+
+        builders = {
+            "camera": lambda: (
+                spaces.Box(0, 255, dtype=np.uint8, shape=cam_shape)
+                if self.uint8_visual
+                else spaces.Box(0, 1, dtype=np.float32, shape=cam_shape)
+            ),
+            "rays": lambda: spaces.Box(0, np.inf, dtype=np.float32, shape=ray_shape),
+            "health": lambda: spaces.Box(0, np.inf, dtype=np.float32, shape=()),
+            "velocity": lambda: spaces.Box(-np.inf, np.inf, dtype=np.float32, shape=(3,)),
+            "position": lambda: spaces.Box(-np.inf, np.inf, dtype=np.float32, shape=(3,)),
+        }
+        obs_spaces = {key: builders[key]() for key in self._obs_keys}
+        if self._single_obs:
+            return obs_spaces[self._obs_keys[0]]
         return spaces.Dict(obs_spaces)
 
-    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> dict:
+    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> Any:
         obs_dict = self._env.get_obs_dict(info.obs)
         out: dict = {}
-        if self.useCamera:
-            out["camera"] = self._preprocess_single(obs_dict["camera"])
-            self.visual_obs = out["camera"]
-        if self.useRayCasts:
-            out["rays"] = np.asarray(obs_dict["rays"], dtype=np.float32)
-        out["health"] = np.asarray(obs_dict["health"], dtype=np.float32)
-        out["velocity"] = np.asarray(obs_dict["velocity"], dtype=np.float32)
-        out["position"] = np.asarray(obs_dict["position"], dtype=np.float32)
+        for key in self._obs_keys:
+            if key == "camera":
+                out["camera"] = self._preprocess_single(obs_dict["camera"])
+                self.visual_obs = out["camera"]
+            else:
+                out[key] = np.asarray(obs_dict[key], dtype=np.float32)
+        if self._single_obs:
+            return out[self._obs_keys[0]]
         return out
+
+    def _reset_unity_env(self, options: Optional[dict]) -> None:
+        arena = options.get("arena_config") if options else None
+        if arena is not None:
+            self._env.reset(arenas_configurations=arena)
+        else:
+            self._env.reset()

--- a/animalai/wrappers/animalai_gymnasium.py
+++ b/animalai/wrappers/animalai_gymnasium.py
@@ -6,8 +6,8 @@ try:
     from gymnasium import spaces
 except ImportError as exc:
     raise ImportError(
-        "The gymnasium wrappers require the optional 'gym' extra. "
-        "Install it with: pip install animalai[gym]"
+        "The gymnasium wrappers require the optional 'gymnasium' extra. "
+        "Install it with: pip install animalai[gymnasium]"
     ) from exc
 
 from mlagents_envs.base_env import DecisionSteps, TerminalSteps

--- a/animalai/wrappers/animalai_gymnasium.py
+++ b/animalai/wrappers/animalai_gymnasium.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 
@@ -59,6 +59,8 @@ class AnimalAIGymnasiumWrapper(UnityToGymnasiumWrapper):
                 "AnimalAIGymnasiumWrapper requires an AnimalAIEnvironment. "
                 "Use UnityToGymnasiumWrapper for other Unity environments."
             )
+
+        self._env : AnimalAIEnvironment
 
         # Whether the env actually produces these streams (drives spec order).
         self._env_camera = unity_env.useCamera
@@ -130,7 +132,9 @@ class AnimalAIGymnasiumWrapper(UnityToGymnasiumWrapper):
             return obs_spaces[self._obs_keys[0]]
         return spaces.Dict(obs_spaces)
 
-    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> Any:
+    def _get_obs(
+        self, info: Union[DecisionSteps, TerminalSteps]
+    ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         obs_dict = self._env.get_obs_dict(info.obs)
         out: dict = {}
         for key in self._obs_keys:

--- a/animalai/wrappers/animalai_gymnasium.py
+++ b/animalai/wrappers/animalai_gymnasium.py
@@ -1,0 +1,84 @@
+from typing import Any, Optional, Union
+
+import numpy as np
+
+try:
+    from gymnasium import spaces
+except ImportError as exc:
+    raise ImportError(
+        "The gymnasium wrappers require the optional 'gym' extra. "
+        "Install it with: pip install animalai[gym]"
+    ) from exc
+
+from mlagents_envs.base_env import DecisionSteps, TerminalSteps
+
+from animalai.environment import AnimalAIEnvironment
+from animalai.wrappers.unity_gymnasium import UnityToGymnasiumWrapper
+
+
+class AnimalAIGymnasiumWrapper(UnityToGymnasiumWrapper):
+    """Animal AI specific Gymnasium wrapper.
+
+    Unlike the generic ``UnityToGymnasiumWrapper``, which returns a single
+    anonymous array, this wrapper returns a dictionary observation matching
+    ``AnimalAIEnvironment.get_obs_dict``. The keys present depend on the
+    environment's ``useCamera`` / ``useRayCasts`` flags; the intrinsic vector
+    (health, velocity, position) is always present.
+
+    This is the recommended wrapper for Animal-AI. The wrapped ``unity_env``
+    must be an ``AnimalAIEnvironment``.
+    """
+
+    def __init__(self, unity_env: AnimalAIEnvironment, **kwargs):
+        if not isinstance(unity_env, AnimalAIEnvironment):
+            raise TypeError(
+                "AnimalAIGymnasiumWrapper requires an AnimalAIEnvironment. "
+                "Use UnityToGymnasiumWrapper for other Unity environments."
+            )
+        self.useCamera = unity_env.useCamera
+        self.useRayCasts = unity_env.useRayCasts
+        super().__init__(unity_env, **kwargs)
+
+    def _build_observation_space(self) -> spaces.Dict:
+        specs = self.group_spec.observation_specs
+        obs_spaces: dict = {}
+        idx = 0
+        if self.useCamera:
+            cam_shape = specs[idx].shape
+            if self.uint8_visual:
+                obs_spaces["camera"] = spaces.Box(
+                    0, 255, dtype=np.uint8, shape=cam_shape
+                )
+            else:
+                obs_spaces["camera"] = spaces.Box(
+                    0, 1, dtype=np.float32, shape=cam_shape
+                )
+            idx += 1
+        if self.useRayCasts:
+            ray_shape = specs[idx].shape
+            obs_spaces["rays"] = spaces.Box(
+                0, np.inf, dtype=np.float32, shape=ray_shape
+            )
+            idx += 1
+        # The intrinsic vector observation (size 7): [health, velocity(3), position(3)].
+        obs_spaces["health"] = spaces.Box(0, np.inf, dtype=np.float32, shape=())
+        obs_spaces["velocity"] = spaces.Box(
+            -np.inf, np.inf, dtype=np.float32, shape=(3,)
+        )
+        obs_spaces["position"] = spaces.Box(
+            -np.inf, np.inf, dtype=np.float32, shape=(3,)
+        )
+        return spaces.Dict(obs_spaces)
+
+    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> dict:
+        obs_dict = self._env.get_obs_dict(info.obs)
+        out: dict = {}
+        if self.useCamera:
+            out["camera"] = self._preprocess_single(obs_dict["camera"])
+            self.visual_obs = out["camera"]
+        if self.useRayCasts:
+            out["rays"] = np.asarray(obs_dict["rays"], dtype=np.float32)
+        out["health"] = np.asarray(obs_dict["health"], dtype=np.float32)
+        out["velocity"] = np.asarray(obs_dict["velocity"], dtype=np.float32)
+        out["position"] = np.asarray(obs_dict["position"], dtype=np.float32)
+        return out

--- a/animalai/wrappers/unity_gymnasium.py
+++ b/animalai/wrappers/unity_gymnasium.py
@@ -4,12 +4,12 @@ from typing import Any, List, Optional, Tuple, Union
 import numpy as np
 
 try:
-    import gymnasium as gym
+    import gymnasium
     from gymnasium import error, spaces
 except ImportError as exc:
     raise ImportError(
-        "The gymnasium wrappers require the optional 'gym' extra. "
-        "Install it with: pip install animalai[gym]"
+        "The gymnasium wrappers require the optional 'gymnasium' extra. "
+        "Install it with: pip install animalai[gymnasium]"
     ) from exc
 
 from mlagents_envs.base_env import ActionTuple, BaseEnv
@@ -26,13 +26,15 @@ class UnityGymnasiumException(error.Error):
 logger = logging_util.get_logger(__name__)
 
 # (observation, reward, terminated, truncated, info)
-GymStepResult = Tuple[Any, float, bool, bool, dict]
+GymnasiumStepResult = Tuple[Any, float, bool, bool, dict]
 
 
-class UnityToGymnasiumWrapper(gym.Env):
+class UnityToGymnasiumWrapper(gymnasium.Env):
     """Wrapper that converts a Unity BaseEnv into a gymnasium.Env.
 
     Based off the UnityToGymWrapper in the ml-agents repo, but updated to work with gymnasium so we aren't version locked.
+
+    see: https://github.com/Unity-Technologies/ml-agents/blob/aeb6f7aee8d9b4aa63329476557d94d87c541146/ml-agents-envs/mlagents_envs/envs/unity_gym_env.py
 
     This is the generic wrapper that should work for all Unity environments.
     """
@@ -109,7 +111,7 @@ class UnityToGymnasiumWrapper(gym.Env):
 
         self.observation_space = self._build_observation_space()
 
-    def _build_action_space(self, flatten_branched: bool) -> gym.Space:
+    def _build_action_space(self, flatten_branched: bool) -> gymnasium.Space:
         if self.group_spec.action_spec.is_discrete():
             self.action_size = self.group_spec.action_spec.discrete_size
             branches = self.group_spec.action_spec.discrete_branches
@@ -135,8 +137,8 @@ class UnityToGymnasiumWrapper(gym.Env):
             "discrete and continuous actions."
         )
 
-    def _build_observation_space(self) -> gym.Space:
-        list_spaces: List[gym.Space] = []
+    def _build_observation_space(self) -> gymnasium.Space:
+        list_spaces: List[gymnasium.Space] = []
         shapes = self._get_vis_obs_shape()
         for shape in shapes:
             if self.uint8_visual:
@@ -185,7 +187,7 @@ class UnityToGymnasiumWrapper(gym.Env):
         """
         self._env.reset()
 
-    def step(self, action: List[Any]) -> GymStepResult:
+    def step(self, action: List[Any]) -> GymnasiumStepResult:
         """Run one timestep and return (obs, reward, terminated, truncated, info)."""
         if self._flattener is not None:
             # Translate the discrete scalar action into a branched action list.
@@ -209,7 +211,7 @@ class UnityToGymnasiumWrapper(gym.Env):
 
     def _single_step(
         self, info: Union[DecisionSteps, TerminalSteps], terminal: bool
-    ) -> GymStepResult:
+    ) -> GymnasiumStepResult:
         obs = self._get_obs(info)
         if terminal:
             # interrupted == hit a step limit (truncation); otherwise a real terminal state.

--- a/animalai/wrappers/unity_gymnasium.py
+++ b/animalai/wrappers/unity_gymnasium.py
@@ -169,13 +169,21 @@ class UnityToGymnasiumWrapper(gym.Env):
         if seed is not None:
             self.action_space.seed(seed)
 
-        self._env.reset()
+        self._reset_unity_env(options)
         decision_step, _ = self._env.get_steps(self.name)
         n_agents = len(decision_step)
         self._check_agents(n_agents)
 
         obs = self._get_obs(decision_step)
         return obs, {"step": decision_step}
+
+    def _reset_unity_env(self, options: Optional[dict]) -> None:
+        """Reset the wrapped Unity env.
+
+        Subclasses can override this to consume ``reset`` options (e.g. to swap
+        the environment configuration) while reusing the rest of ``reset``.
+        """
+        self._env.reset()
 
     def step(self, action: List[Any]) -> GymStepResult:
         """Run one timestep and return (obs, reward, terminated, truncated, info)."""

--- a/animalai/wrappers/unity_gymnasium.py
+++ b/animalai/wrappers/unity_gymnasium.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -25,8 +25,16 @@ class UnityGymnasiumException(error.Error):
 
 logger = logging_util.get_logger(__name__)
 
+# Every observation is built from ndarrays; only the container varies by
+# wrapper / flags: a bare array, a list of arrays (allow_multiple_obs), or a
+# dict of arrays keyed by stream name (AnimalAIGymnasiumWrapper).
+Observation = Union[np.ndarray, List[np.ndarray], Dict[str, np.ndarray]]
+# Action shape is fixed by the wrapper: Discrete -> int, MultiDiscrete/Box ->
+# ndarray, flattened-branch lookup -> list of ints.
+ActType = Union[int, np.ndarray, Sequence[int]]
+
 # (observation, reward, terminated, truncated, info)
-GymnasiumStepResult = Tuple[Any, float, bool, bool, dict]
+GymnasiumStepResult = Tuple[Observation, float, bool, bool, dict]
 
 
 class UnityToGymnasiumWrapper(gymnasium.Env):
@@ -165,7 +173,7 @@ class UnityToGymnasiumWrapper(gymnasium.Env):
         *,
         seed: Optional[int] = None,
         options: Optional[dict] = None,
-    ) -> Tuple[Any, dict]:
+    ) -> Tuple[Observation, dict]:
         """Reset the environment and return the initial observation and info dict."""
         super().reset(seed=seed)
         if seed is not None:
@@ -187,7 +195,7 @@ class UnityToGymnasiumWrapper(gymnasium.Env):
         """
         self._env.reset()
 
-    def step(self, action: List[Any]) -> GymnasiumStepResult:
+    def step(self, action: ActType) -> GymnasiumStepResult:
         """Run one timestep and return (obs, reward, terminated, truncated, info)."""
         if self._flattener is not None:
             # Translate the discrete scalar action into a branched action list.
@@ -223,7 +231,7 @@ class UnityToGymnasiumWrapper(gymnasium.Env):
             truncated = False
         return obs, float(info.reward[0]), terminated, truncated, {"step": info}
 
-    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> Any:
+    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> Observation:
         """Build the observation for the current step.
 
         Subclasses can override this to change the observation format while
@@ -231,7 +239,7 @@ class UnityToGymnasiumWrapper(gymnasium.Env):
         """
         if self._allow_multiple_obs:
             visual_obs = self._get_vis_obs_list(info)
-            default_observation: Any = [
+            default_observation = [
                 self._preprocess_single(obs[0]) for obs in visual_obs
             ]
             if self._get_vec_obs_size() >= 1:

--- a/animalai/wrappers/unity_gymnasium.py
+++ b/animalai/wrappers/unity_gymnasium.py
@@ -1,0 +1,334 @@
+import itertools
+from typing import Any, List, Optional, Tuple, Union
+
+import numpy as np
+
+try:
+    import gymnasium as gym
+    from gymnasium import error, spaces
+except ImportError as exc:
+    raise ImportError(
+        "The gymnasium wrappers require the optional 'gym' extra. "
+        "Install it with: pip install animalai[gym]"
+    ) from exc
+
+from mlagents_envs.base_env import ActionTuple, BaseEnv
+from mlagents_envs.base_env import DecisionSteps, TerminalSteps
+from mlagents_envs import logging_util
+
+
+class UnityGymnasiumException(error.Error):
+    """Any error related to the gymnasium wrapper of ml-agents."""
+
+    pass
+
+
+logger = logging_util.get_logger(__name__)
+
+# (observation, reward, terminated, truncated, info)
+GymStepResult = Tuple[Any, float, bool, bool, dict]
+
+
+class UnityToGymnasiumWrapper(gym.Env):
+    """Wrapper that converts a Unity BaseEnv into a gymnasium.Env.
+
+    Based off the UnityToGymWrapper in the ml-agents repo, but updated to work with gymnasium so we aren't version locked.
+
+    This is the generic wrapper that should work for all Unity environments.
+    """
+
+    metadata = {"render_modes": ["rgb_array"]}
+
+    def __init__(
+        self,
+        unity_env: BaseEnv,
+        uint8_visual: bool = False,
+        flatten_branched: bool = False,
+        allow_multiple_obs: bool = False,
+        action_space_seed: Optional[int] = None,
+        render_mode: Optional[str] = "rgb_array",
+    ):
+        """
+        Environment initialization.
+
+        Args:
+          unity_env: The Unity BaseEnv to wrap. It is closed when this wrapper closes.
+          uint8_visual: Return visual observations as uint8 (0-255) instead of float (0.0-1.0).
+          flatten_branched: If True, turn a branched discrete action space into a single
+            Discrete space rather than a MultiDiscrete space.
+          allow_multiple_obs: If True, return a list of np.ndarrays as observations, with the
+            leading elements containing the visual observations and the final element containing
+            the vector observations. If False, return a single np.ndarray containing either a
+            single visual observation or the vector observation.
+          action_space_seed: If non-None, used to seed the created action space.
+          render_mode: The render mode. Only "rgb_array" is supported.
+        """
+        self._env = unity_env
+
+        # Take a single step so that the brain information will be sent over.
+        if not self._env.behavior_specs:
+            self._env.step()
+
+        self.render_mode = render_mode
+        self.visual_obs = None
+        self.uint8_visual = uint8_visual
+
+        self._previous_decision_step: Optional[DecisionSteps] = None
+        self._flattener = None
+        self._allow_multiple_obs = allow_multiple_obs
+
+        if len(self._env.behavior_specs) != 1:
+            raise UnityGymnasiumException(
+                "There can only be one behavior in a UnityEnvironment "
+                "if it is wrapped in a gymnasium env."
+            )
+
+        self.name = list(self._env.behavior_specs.keys())[0]
+        self.group_spec = self._env.behavior_specs[self.name]
+
+        if self._get_n_vis_obs() == 0 and self._get_vec_obs_size() == 0:
+            raise UnityGymnasiumException(
+                "There are no observations provided by the environment."
+            )
+
+        if not self._get_n_vis_obs() >= 1 and uint8_visual:
+            logger.warning(
+                "uint8_visual was set to true, but visual observations are not in use. "
+                "This setting will not have any effect."
+            )
+
+        # Check for number of agents in scene.
+        self._env.reset()
+        decision_steps, _ = self._env.get_steps(self.name)
+        self._check_agents(len(decision_steps))
+        self._previous_decision_step = decision_steps
+
+        self.action_space = self._build_action_space(flatten_branched)
+        if action_space_seed is not None:
+            self.action_space.seed(action_space_seed)
+
+        self.observation_space = self._build_observation_space()
+
+    def _build_action_space(self, flatten_branched: bool) -> gym.Space:
+        if self.group_spec.action_spec.is_discrete():
+            self.action_size = self.group_spec.action_spec.discrete_size
+            branches = self.group_spec.action_spec.discrete_branches
+            if self.group_spec.action_spec.discrete_size == 1:
+                return spaces.Discrete(branches[0])
+            if flatten_branched:
+                self._flattener = ActionFlattener(branches)
+                return self._flattener.action_space
+            return spaces.MultiDiscrete(branches)
+
+        if self.group_spec.action_spec.is_continuous():
+            if flatten_branched:
+                logger.warning(
+                    "The environment has a non-discrete action space. It will "
+                    "not be flattened."
+                )
+            self.action_size = self.group_spec.action_spec.continuous_size
+            high = np.ones(self.group_spec.action_spec.continuous_size, dtype=np.float32)
+            return spaces.Box(-high, high, dtype=np.float32)
+
+        raise UnityGymnasiumException(
+            "The gymnasium wrapper does not provide explicit support for both "
+            "discrete and continuous actions."
+        )
+
+    def _build_observation_space(self) -> gym.Space:
+        list_spaces: List[gym.Space] = []
+        shapes = self._get_vis_obs_shape()
+        for shape in shapes:
+            if self.uint8_visual:
+                list_spaces.append(spaces.Box(0, 255, dtype=np.uint8, shape=shape))
+            else:
+                list_spaces.append(spaces.Box(0, 1, dtype=np.float32, shape=shape))
+        if self._get_vec_obs_size() > 0:
+            # Vector observation is last.
+            high = np.full(self._get_vec_obs_size(), np.inf, dtype=np.float32)
+            list_spaces.append(spaces.Box(-high, high, dtype=np.float32))
+        if self._allow_multiple_obs:
+            return spaces.Tuple(list_spaces)
+        if len(list_spaces) >= 2:
+            logger.warning(
+                "The environment contains multiple observations. "
+                "You must define allow_multiple_obs=True to receive them all. "
+                "Otherwise, only the first visual observation (or the vector "
+                "observation if there are no visual observations) will be provided."
+            )
+        return list_spaces[0]  # only return the first one
+
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Optional[dict] = None,
+    ) -> Tuple[Any, dict]:
+        """Reset the environment and return the initial observation and info dict."""
+        super().reset(seed=seed)
+        if seed is not None:
+            self.action_space.seed(seed)
+
+        self._env.reset()
+        decision_step, _ = self._env.get_steps(self.name)
+        n_agents = len(decision_step)
+        self._check_agents(n_agents)
+
+        obs = self._get_obs(decision_step)
+        return obs, {"step": decision_step}
+
+    def step(self, action: List[Any]) -> GymStepResult:
+        """Run one timestep and return (obs, reward, terminated, truncated, info)."""
+        if self._flattener is not None:
+            # Translate the discrete scalar action into a branched action list.
+            action = self._flattener.lookup_action(action)
+
+        action = np.array(action).reshape((1, self.action_size))
+
+        action_tuple = ActionTuple()
+        if self.group_spec.action_spec.is_continuous():
+            action_tuple.add_continuous(action)
+        else:
+            action_tuple.add_discrete(action)
+        self._env.set_actions(self.name, action_tuple)
+
+        self._env.step()
+        decision_step, terminal_step = self._env.get_steps(self.name)
+        self._check_agents(max(len(decision_step), len(terminal_step)))
+        if len(terminal_step) != 0:
+            return self._single_step(terminal_step, terminal=True)
+        return self._single_step(decision_step, terminal=False)
+
+    def _single_step(
+        self, info: Union[DecisionSteps, TerminalSteps], terminal: bool
+    ) -> GymStepResult:
+        obs = self._get_obs(info)
+        if terminal:
+            # interrupted == hit a step limit (truncation); otherwise a real terminal state.
+            interrupted = bool(info.interrupted[0])
+            terminated = not interrupted
+            truncated = interrupted
+        else:
+            terminated = False
+            truncated = False
+        return obs, float(info.reward[0]), terminated, truncated, {"step": info}
+
+    def _get_obs(self, info: Union[DecisionSteps, TerminalSteps]) -> Any:
+        """Build the observation for the current step.
+
+        Subclasses can override this to change the observation format while
+        reusing the reward / terminated / truncated logic in ``_single_step``.
+        """
+        if self._allow_multiple_obs:
+            visual_obs = self._get_vis_obs_list(info)
+            default_observation: Any = [
+                self._preprocess_single(obs[0]) for obs in visual_obs
+            ]
+            if self._get_vec_obs_size() >= 1:
+                default_observation.append(self._get_vector_obs(info)[0, :])
+        else:
+            if self._get_n_vis_obs() >= 1:
+                visual_obs = self._get_vis_obs_list(info)
+                default_observation = self._preprocess_single(visual_obs[0][0])
+            else:
+                default_observation = self._get_vector_obs(info)[0, :]
+
+        if self._get_n_vis_obs() >= 1:
+            visual_obs = self._get_vis_obs_list(info)
+            self.visual_obs = self._preprocess_single(visual_obs[0][0])
+
+        return default_observation
+
+    def _preprocess_single(self, single_visual_obs: np.ndarray) -> np.ndarray:
+        if self.uint8_visual:
+            return (255.0 * single_visual_obs).astype(np.uint8)
+        return single_visual_obs
+
+    def _get_n_vis_obs(self) -> int:
+        result = 0
+        for obs_spec in self.group_spec.observation_specs:
+            if len(obs_spec.shape) == 3:
+                result += 1
+        return result
+
+    def _get_vis_obs_shape(self) -> List[Tuple]:
+        result: List[Tuple] = []
+        for obs_spec in self.group_spec.observation_specs:
+            if len(obs_spec.shape) == 3:
+                result.append(obs_spec.shape)
+        return result
+
+    def _get_vis_obs_list(
+        self, step_result: Union[DecisionSteps, TerminalSteps]
+    ) -> List[np.ndarray]:
+        result: List[np.ndarray] = []
+        for obs in step_result.obs:
+            if len(obs.shape) == 4:
+                result.append(obs)
+        return result
+
+    def _get_vector_obs(
+        self, step_result: Union[DecisionSteps, TerminalSteps]
+    ) -> np.ndarray:
+        result: List[np.ndarray] = []
+        for obs in step_result.obs:
+            if len(obs.shape) == 2:
+                result.append(obs)
+        return np.concatenate(result, axis=1)
+
+    def _get_vec_obs_size(self) -> int:
+        result = 0
+        for obs_spec in self.group_spec.observation_specs:
+            if len(obs_spec.shape) == 1:
+                result += obs_spec.shape[0]
+        return result
+
+    def render(self):
+        """Return the latest visual observation.
+
+        Note that this does not render a new frame of the environment.
+        """
+        return self.visual_obs
+
+    def close(self) -> None:
+        """Close the wrapped Unity environment."""
+        self._env.close()
+
+    @property
+    def reward_range(self) -> Tuple[float, float]:
+        return -float("inf"), float("inf")
+
+    @staticmethod
+    def _check_agents(n_agents: int) -> None:
+        if n_agents > 1:
+            raise UnityGymnasiumException(
+                f"There can only be one Agent in the environment but {n_agents} were detected."
+            )
+
+
+class ActionFlattener:
+    """Flattens branched discrete action spaces into single-branch discrete spaces."""
+
+    def __init__(self, branched_action_space):
+        """
+        Args:
+          branched_action_space: A list of the sizes of each branch of the action
+            space, e.g. [2, 3, 3] for three branches of size 2, 3 and 3.
+        """
+        self._action_shape = branched_action_space
+        self.action_lookup = self._create_lookup(self._action_shape)
+        self.action_space = spaces.Discrete(len(self.action_lookup))
+
+    @classmethod
+    def _create_lookup(cls, branched_action_space):
+        """Create a dict mapping discrete scalar actions to branched action lists."""
+        possible_vals = [range(_num) for _num in branched_action_space]
+        all_actions = [list(_action) for _action in itertools.product(*possible_vals)]
+        action_lookup = {
+            _scalar: _action for (_scalar, _action) in enumerate(all_actions)
+        }
+        return action_lookup
+
+    def lookup_action(self, action):
+        """Convert a scalar discrete action into its branched action list."""
+        return self.action_lookup[action]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 inspect-ai = [
     "inspect-ai>=0.3.205",
 ]
+gym = [
+    "gymnasium>=1.0",
+]
 
 [project.urls]
 "Website"         = "https://animalai.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 inspect-ai = [
     "inspect-ai>=0.3.205",
 ]
-gym = [
+gymnasium = [
     "gymnasium>=1.0",
 ]
 

--- a/tests/wrappers/test_animalai_gymnasium.py
+++ b/tests/wrappers/test_animalai_gymnasium.py
@@ -200,6 +200,103 @@ class TestObservations(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Observation selection
+# ---------------------------------------------------------------------------
+
+class TestObservationSelection(unittest.TestCase):
+    def test_single_camera_is_bare_box(self):
+        wrapper = AnimalAIGymnasiumWrapper(
+            _make_env(useCamera=True, useRayCasts=True),
+            include_camera=True,
+            include_rays=False,
+            include_health=False,
+            include_velocity=False,
+            include_position=False,
+        )
+        self.assertIsInstance(wrapper.observation_space, spaces.Box)
+        self.assertEqual(wrapper.observation_space.shape, (4, 4, 3))
+        obs, _ = wrapper.reset()
+        self.assertIsInstance(obs, np.ndarray)
+        self.assertEqual(obs.shape, (4, 4, 3))
+        self.assertTrue(wrapper.observation_space.contains(obs))
+        step_obs = wrapper.step([1, 0])[0]
+        self.assertIsInstance(step_obs, np.ndarray)
+        self.assertEqual(step_obs.shape, (4, 4, 3))
+
+    def test_single_rays_is_bare_box(self):
+        wrapper = AnimalAIGymnasiumWrapper(
+            _make_env(useCamera=True, useRayCasts=True),
+            include_camera=False,
+            include_rays=True,
+            include_health=False,
+            include_velocity=False,
+            include_position=False,
+        )
+        self.assertIsInstance(wrapper.observation_space, spaces.Box)
+        self.assertEqual(wrapper.observation_space.shape, (6,))
+        obs, _ = wrapper.reset()
+        self.assertIsInstance(obs, np.ndarray)
+        self.assertEqual(obs.shape, (6,))
+
+    def test_two_streams_is_dict_with_only_those_keys(self):
+        wrapper = AnimalAIGymnasiumWrapper(
+            _make_env(useCamera=True, useRayCasts=False),
+            include_camera=True,
+            include_health=False,
+            include_velocity=False,
+            include_position=True,
+        )
+        self.assertIsInstance(wrapper.observation_space, spaces.Dict)
+        self.assertEqual(set(wrapper.observation_space.spaces), {"camera", "position"})
+        obs, _ = wrapper.reset()
+        self.assertEqual(set(obs), {"camera", "position"})
+
+    def test_default_is_full_dict(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(useCamera=True, useRayCasts=True))
+        self.assertIsInstance(wrapper.observation_space, spaces.Dict)
+        self.assertEqual(
+            set(wrapper.observation_space.spaces),
+            {"camera", "rays", "health", "velocity", "position"},
+        )
+
+    def test_require_camera_when_absent_raises(self):
+        with self.assertRaises(ValueError):
+            AnimalAIGymnasiumWrapper(
+                _make_env(useCamera=False, useRayCasts=True),
+                include_camera=True,
+            )
+
+    def test_no_streams_selected_raises(self):
+        with self.assertRaises(ValueError):
+            AnimalAIGymnasiumWrapper(
+                _make_env(useCamera=False, useRayCasts=False),
+                include_health=False,
+                include_velocity=False,
+                include_position=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Arena swap via reset(options=...)
+# ---------------------------------------------------------------------------
+
+class TestArenaSwap(unittest.TestCase):
+    def test_reset_with_arena_config_forwarded(self):
+        env = _make_env()
+        wrapper = AnimalAIGymnasiumWrapper(env)
+        env.reset.reset_mock()
+        wrapper.reset(options={"arena_config": "some/arena.yml"})
+        env.reset.assert_called_once_with(arenas_configurations="some/arena.yml")
+
+    def test_reset_without_options_uses_default_arena(self):
+        env = _make_env()
+        wrapper = AnimalAIGymnasiumWrapper(env)
+        env.reset.reset_mock()
+        wrapper.reset()
+        env.reset.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
 # Guards
 # ---------------------------------------------------------------------------
 

--- a/tests/wrappers/test_animalai_gymnasium.py
+++ b/tests/wrappers/test_animalai_gymnasium.py
@@ -1,0 +1,213 @@
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+from gymnasium import spaces
+
+from animalai.environment import AnimalAIEnvironment
+from animalai.wrappers.animalai_gymnasium import AnimalAIGymnasiumWrapper
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _ObsSpec:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _ActionSpec:
+    discrete_branches = (3, 3)
+    continuous_size = 0
+
+    @property
+    def discrete_size(self):
+        return len(self.discrete_branches)
+
+    def is_discrete(self):
+        return True
+
+    def is_continuous(self):
+        return False
+
+
+class _BehaviorSpec:
+    def __init__(self, observation_specs):
+        self.observation_specs = observation_specs
+        self.action_spec = _ActionSpec()
+
+
+class _Steps:
+    def __init__(self, obs, reward, n=1, interrupted=None):
+        self.obs = obs
+        self.reward = reward
+        self._n = n
+        if interrupted is not None:
+            self.interrupted = interrupted
+
+    def __len__(self):
+        return self._n
+
+
+class _FakeAAIEnv(AnimalAIEnvironment):
+    """An AnimalAIEnvironment that skips the real Unity launch.
+
+    Subclassing the real class satisfies the wrapper's isinstance check, while
+    the inherited get_obs_dict() runs against the fake step observations.
+    """
+
+    def __init__(self, observation_specs, decision, terminal, useCamera, useRayCasts):
+        self.useCamera = useCamera
+        self.useRayCasts = useRayCasts
+        self.obsdict = {
+            "camera": [],
+            "rays": [],
+            "health": [],
+            "velocity": [],
+            "position": [],
+        }
+        self._specs = {"Brain?team=0": _BehaviorSpec(observation_specs)}
+        self._decision = decision
+        self._terminal = terminal
+        self.set_actions = MagicMock()
+        self.step = MagicMock()
+        self.reset = MagicMock()
+        self.closed = False
+
+    @property
+    def behavior_specs(self):
+        return self._specs
+
+    def get_steps(self, name):
+        return self._decision, self._terminal
+
+    def close(self):
+        self.closed = True
+
+
+def _camera_batch(h=4, w=4, c=3, val=0.5):
+    return np.full((1, h, w, c), val, dtype=np.float32)
+
+
+def _vector_batch(health=5.0, velocity=(1.0, 2.0, 3.0), position=(7.0, 8.0, 9.0)):
+    return np.array([[health, *velocity, *position]], dtype=np.float32)
+
+
+def _rays_batch(length=6, val=0.3):
+    return np.full((1, length), val, dtype=np.float32)
+
+
+def _empty_terminal():
+    return _Steps(obs=[], reward=[], n=0)
+
+
+def _make_env(useCamera=True, useRayCasts=False, camera_val=0.5):
+    specs = []
+    obs = []
+    if useCamera:
+        specs.append(_ObsSpec((4, 4, 3)))
+        obs.append(_camera_batch(val=camera_val))
+    if useRayCasts:
+        specs.append(_ObsSpec((6,)))
+        obs.append(_rays_batch())
+    specs.append(_ObsSpec((7,)))
+    obs.append(_vector_batch())
+    decision = _Steps(obs=obs, reward=[0.0], n=1)
+    return _FakeAAIEnv(specs, decision, _empty_terminal(), useCamera, useRayCasts)
+
+
+# ---------------------------------------------------------------------------
+# Observation space
+# ---------------------------------------------------------------------------
+
+class TestObservationSpace(unittest.TestCase):
+    def test_camera_only_keys(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(useCamera=True, useRayCasts=False))
+        self.assertIsInstance(wrapper.observation_space, spaces.Dict)
+        self.assertEqual(
+            set(wrapper.observation_space.spaces),
+            {"camera", "health", "velocity", "position"},
+        )
+
+    def test_camera_and_rays_keys(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(useCamera=True, useRayCasts=True))
+        self.assertEqual(
+            set(wrapper.observation_space.spaces),
+            {"camera", "rays", "health", "velocity", "position"},
+        )
+        self.assertEqual(wrapper.observation_space["rays"].shape, (6,))
+
+    def test_rays_only_keys(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(useCamera=False, useRayCasts=True))
+        self.assertEqual(
+            set(wrapper.observation_space.spaces),
+            {"rays", "health", "velocity", "position"},
+        )
+
+    def test_camera_space_shape_and_dtype(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env())
+        cam = wrapper.observation_space["camera"]
+        self.assertEqual(cam.shape, (4, 4, 3))
+        self.assertEqual(cam.dtype, np.float32)
+
+    def test_camera_uint8(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(), uint8_visual=True)
+        self.assertEqual(wrapper.observation_space["camera"].dtype, np.uint8)
+
+    def test_vector_subspaces(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env())
+        self.assertEqual(wrapper.observation_space["health"].shape, ())
+        self.assertEqual(wrapper.observation_space["velocity"].shape, (3,))
+        self.assertEqual(wrapper.observation_space["position"].shape, (3,))
+
+
+# ---------------------------------------------------------------------------
+# Observations from reset / step
+# ---------------------------------------------------------------------------
+
+class TestObservations(unittest.TestCase):
+    def test_reset_returns_dict_obs(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(useCamera=True, useRayCasts=True))
+        obs, info = wrapper.reset()
+        self.assertEqual(
+            set(obs), {"camera", "rays", "health", "velocity", "position"}
+        )
+        self.assertTrue(wrapper.observation_space.contains(obs))
+
+    def test_obs_values_parsed(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env())
+        obs, _ = wrapper.reset()
+        self.assertEqual(obs["health"].shape, ())
+        np.testing.assert_array_equal(obs["health"], np.float32(5.0))
+        np.testing.assert_array_equal(obs["velocity"], [1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(obs["position"], [7.0, 8.0, 9.0])
+
+    def test_camera_uint8_conversion(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env(camera_val=0.5), uint8_visual=True)
+        obs, _ = wrapper.reset()
+        self.assertEqual(obs["camera"].dtype, np.uint8)
+        self.assertEqual(int(obs["camera"].flat[0]), 127)
+
+    def test_step_returns_dict_obs_in_5_tuple(self):
+        wrapper = AnimalAIGymnasiumWrapper(_make_env())
+        result = wrapper.step([1, 0])
+        self.assertEqual(len(result), 5)
+        obs, reward, terminated, truncated, info = result
+        self.assertIn("camera", obs)
+        self.assertFalse(terminated)
+        self.assertFalse(truncated)
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+class TestGuards(unittest.TestCase):
+    def test_rejects_non_aai_env(self):
+        with self.assertRaises(TypeError):
+            AnimalAIGymnasiumWrapper(MagicMock())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/wrappers/test_unity_gymnasium.py
+++ b/tests/wrappers/test_unity_gymnasium.py
@@ -1,0 +1,250 @@
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+from gymnasium import spaces
+
+from animalai.wrappers.unity_gymnasium import (
+    ActionFlattener,
+    UnityGymnasiumException,
+    UnityToGymnasiumWrapper,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the mlagents_envs BaseEnv API (no Unity binary involved)
+# ---------------------------------------------------------------------------
+
+class _ObsSpec:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _ActionSpec:
+    def __init__(self, discrete_branches=(3, 3), continuous_size=0):
+        self.discrete_branches = discrete_branches
+        self.continuous_size = continuous_size
+
+    @property
+    def discrete_size(self):
+        return len(self.discrete_branches)
+
+    def is_discrete(self):
+        return self.continuous_size == 0
+
+    def is_continuous(self):
+        return self.continuous_size > 0
+
+
+class _BehaviorSpec:
+    def __init__(self, observation_specs, action_spec):
+        self.observation_specs = observation_specs
+        self.action_spec = action_spec
+
+
+class _Steps:
+    def __init__(self, obs, reward, n=1, interrupted=None):
+        self.obs = obs
+        self.reward = reward
+        self._n = n
+        if interrupted is not None:
+            self.interrupted = interrupted
+
+    def __len__(self):
+        return self._n
+
+
+class _FakeEnv:
+    def __init__(self, behavior_spec, decision_steps, terminal_steps, name="Brain?team=0"):
+        self.behavior_specs = {name: behavior_spec}
+        self._decision = decision_steps
+        self._terminal = terminal_steps
+        self.set_actions = MagicMock()
+        self.step = MagicMock()
+        self.reset = MagicMock()
+        self.closed = False
+
+    def get_steps(self, name):
+        return self._decision, self._terminal
+
+    def close(self):
+        self.closed = True
+
+
+def _camera_obs(h=4, w=4, c=3, val=0.5):
+    return np.full((1, h, w, c), val, dtype=np.float32)
+
+
+def _vector_obs(values):
+    return np.array([values], dtype=np.float32)
+
+
+def _empty_terminal():
+    return _Steps(obs=[], reward=[], n=0)
+
+
+def _make_vector_env(n_decision=1):
+    spec = _BehaviorSpec([_ObsSpec((7,))], _ActionSpec())
+    obs = [_vector_obs([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])]
+    decision = _Steps(obs=obs, reward=[0.0], n=n_decision)
+    return _FakeEnv(spec, decision, _empty_terminal())
+
+
+def _make_visual_env(uint8_val=0.5):
+    spec = _BehaviorSpec([_ObsSpec((4, 4, 3))], _ActionSpec())
+    decision = _Steps(obs=[_camera_obs(val=uint8_val)], reward=[0.0], n=1)
+    return _FakeEnv(spec, decision, _empty_terminal())
+
+
+def _make_multi_env():
+    spec = _BehaviorSpec([_ObsSpec((4, 4, 3)), _ObsSpec((7,))], _ActionSpec())
+    obs = [_camera_obs(), _vector_obs([0.0] * 7)]
+    decision = _Steps(obs=obs, reward=[0.0], n=1)
+    return _FakeEnv(spec, decision, _empty_terminal())
+
+
+# ---------------------------------------------------------------------------
+# Action space
+# ---------------------------------------------------------------------------
+
+class TestActionSpace(unittest.TestCase):
+    def test_default_is_multidiscrete(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env())
+        self.assertIsInstance(wrapper.action_space, spaces.MultiDiscrete)
+        np.testing.assert_array_equal(wrapper.action_space.nvec, [3, 3])
+
+    def test_flatten_branched_is_discrete(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env(), flatten_branched=True)
+        self.assertIsInstance(wrapper.action_space, spaces.Discrete)
+        self.assertEqual(wrapper.action_space.n, 9)
+
+    def test_action_space_seeded(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env(), action_space_seed=123)
+        first = wrapper.action_space.sample()
+        wrapper.action_space.seed(123)
+        np.testing.assert_array_equal(wrapper.action_space.sample(), first)
+
+
+class TestActionFlattener(unittest.TestCase):
+    def test_lookup_maps_scalar_to_branches(self):
+        flattener = ActionFlattener([3, 3])
+        self.assertEqual(flattener.action_space.n, 9)
+        self.assertEqual(flattener.lookup_action(0), [0, 0])
+        self.assertEqual(flattener.lookup_action(4), [1, 1])
+        self.assertEqual(flattener.lookup_action(8), [2, 2])
+
+
+# ---------------------------------------------------------------------------
+# Observation space
+# ---------------------------------------------------------------------------
+
+class TestObservationSpace(unittest.TestCase):
+    def test_vector_only(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env())
+        self.assertIsInstance(wrapper.observation_space, spaces.Box)
+        self.assertEqual(wrapper.observation_space.shape, (7,))
+
+    def test_visual_only_float(self):
+        wrapper = UnityToGymnasiumWrapper(_make_visual_env())
+        self.assertEqual(wrapper.observation_space.shape, (4, 4, 3))
+        self.assertEqual(wrapper.observation_space.dtype, np.float32)
+
+    def test_visual_only_uint8(self):
+        wrapper = UnityToGymnasiumWrapper(_make_visual_env(), uint8_visual=True)
+        self.assertEqual(wrapper.observation_space.dtype, np.uint8)
+        self.assertEqual(wrapper.observation_space.high.max(), 255)
+
+    def test_multi_default_returns_first_visual(self):
+        wrapper = UnityToGymnasiumWrapper(_make_multi_env())
+        self.assertIsInstance(wrapper.observation_space, spaces.Box)
+        self.assertEqual(wrapper.observation_space.shape, (4, 4, 3))
+
+    def test_multi_allow_multiple_returns_tuple(self):
+        wrapper = UnityToGymnasiumWrapper(_make_multi_env(), allow_multiple_obs=True)
+        self.assertIsInstance(wrapper.observation_space, spaces.Tuple)
+        self.assertEqual(len(wrapper.observation_space.spaces), 2)
+
+
+# ---------------------------------------------------------------------------
+# reset / step
+# ---------------------------------------------------------------------------
+
+class TestResetStep(unittest.TestCase):
+    def test_reset_returns_obs_and_info(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env())
+        obs, info = wrapper.reset()
+        self.assertEqual(obs.shape, (7,))
+        self.assertIn("step", info)
+
+    def test_reset_seeds_action_space(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env())
+        obs, _ = wrapper.reset(seed=42)
+        first = wrapper.action_space.sample()
+        wrapper.reset(seed=42)
+        np.testing.assert_array_equal(wrapper.action_space.sample(), first)
+
+    def test_step_decision_returns_5_tuple(self):
+        wrapper = UnityToGymnasiumWrapper(_make_vector_env())
+        result = wrapper.step([1, 0])
+        self.assertEqual(len(result), 5)
+        obs, reward, terminated, truncated, info = result
+        self.assertFalse(terminated)
+        self.assertFalse(truncated)
+        self.assertEqual(reward, 0.0)
+
+    def test_step_terminated_when_not_interrupted(self):
+        env = _make_vector_env()
+        env._terminal = _Steps(
+            obs=[_vector_obs([1.0] * 7)], reward=[2.5], n=1, interrupted=[False]
+        )
+        wrapper = UnityToGymnasiumWrapper(env)
+        _, reward, terminated, truncated, _ = wrapper.step([1, 0])
+        self.assertTrue(terminated)
+        self.assertFalse(truncated)
+        self.assertEqual(reward, 2.5)
+
+    def test_step_truncated_when_interrupted(self):
+        env = _make_vector_env()
+        env._terminal = _Steps(
+            obs=[_vector_obs([1.0] * 7)], reward=[0.0], n=1, interrupted=[True]
+        )
+        wrapper = UnityToGymnasiumWrapper(env)
+        _, _, terminated, truncated, _ = wrapper.step([1, 0])
+        self.assertFalse(terminated)
+        self.assertTrue(truncated)
+
+    def test_step_sends_action_tuple(self):
+        env = _make_vector_env()
+        wrapper = UnityToGymnasiumWrapper(env)
+        wrapper.step([2, 1])
+        env.set_actions.assert_called()
+        _, action_tuple = env.set_actions.call_args.args
+        np.testing.assert_array_equal(action_tuple.discrete, [[2, 1]])
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+class TestMisc(unittest.TestCase):
+    def test_no_observations_raises(self):
+        spec = _BehaviorSpec([], _ActionSpec())
+        env = _FakeEnv(spec, _Steps(obs=[], reward=[0.0], n=1), _empty_terminal())
+        with self.assertRaises(UnityGymnasiumException):
+            UnityToGymnasiumWrapper(env)
+
+    def test_close_delegates(self):
+        env = _make_vector_env()
+        wrapper = UnityToGymnasiumWrapper(env)
+        wrapper.close()
+        self.assertTrue(env.closed)
+
+    def test_render_returns_latest_visual(self):
+        wrapper = UnityToGymnasiumWrapper(_make_visual_env())
+        wrapper.reset()
+        frame = wrapper.render()
+        self.assertEqual(frame.shape, (4, 4, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Description

Old mlagents included a UnityToGym wrapper that was really useful for doing RL in AAI as it handled all the formatting of the inputs and outputs and fit nicely into existing training tools like Pytorch. Now that we have changed over to our own fork we no longer have access to that since gym requires python <=3.14. Thus it would be useful to have a new wrapper to fill that role.

This PR adds a Gymnasium wrapper with is the new maintained version of gym which supports newer versions of python (although with some slight formatting differences from gym). It also adds and AAI specific wrapper which has the outputs marked specifically for animal ai.

### Proposed change(s)

Added two unity to gymnasium wrappers, one generic for any unity environment and a specific subclass for animalai.

### Useful links (Github issues, discussion threads, etc.)

[link to Doc change PR](https://github.com/Kinds-of-Intelligence-CFI/animal-ai/pull/65)

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [x] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

I still need to add the doc changes PR for this will link.

### Screenshots (if any)
