### PR TITLE
Vectorised envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you are new to contributing to open source, [this](https://github.com/Kinds-o
 ## Version History
 * v6.1.3
   + Added UnityToGymnasium and AnimalAIGymnasiumWrapper wrappers  
+  + Added make_animalai_vec_env / make_animalai_env_fns helpers for vectorised (parallel) environments  
 * v6.1.2
   + Fixed the version string for the executable autodownload
   + Misc fixes to the inspect wrapper

--- a/animalai/wrappers/__init__.py
+++ b/animalai/wrappers/__init__.py
@@ -3,6 +3,8 @@ __all__ = [
     "UnityGymnasiumException",
     "ActionFlattener",
     "AnimalAIGymnasiumWrapper",
+    "make_animalai_env_fns",
+    "make_animalai_vec_env",
 ]
 
 
@@ -15,4 +17,8 @@ def __getattr__(name):
         from animalai.wrappers.animalai_gymnasium import AnimalAIGymnasiumWrapper
 
         return AnimalAIGymnasiumWrapper
+    if name in ("make_animalai_env_fns", "make_animalai_vec_env"):
+        from animalai.wrappers import vector
+
+        return getattr(vector, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/animalai/wrappers/vector.py
+++ b/animalai/wrappers/vector.py
@@ -9,14 +9,18 @@ each with a unique ``worker_id`` (and ``seed``) so ports do not collide -- and
 composing them with Gymnasium's built-in vector envs.
 """
 
+import os
+import tempfile
+from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 try:
     import gymnasium
+    from filelock import FileLock
 except ImportError as exc:
     raise ImportError(
-        "The gymnasium wrappers require the optional 'gym' extra. "
-        "Install it with: pip install animalai[gym]"
+        "The gymnasium wrappers require the optional 'gymnasium' extra. "
+        "Install it with: pip install animalai[gymnasium]"
     ) from exc
 
 from animalai.environment import AnimalAIEnvironment
@@ -38,6 +42,9 @@ def make_animalai_env_fns(
     arenas_configurations: ArenaConfig = "",
     env_kwargs: Optional[Dict[str, Any]] = None,
     wrapper_kwargs: Optional[Dict[str, Any]] = None,
+    serialize_launch: bool = True,
+    launch_lock_timeout: float = 300.0,
+    launch_lock_path: Optional[str] = None,
 ) -> List[Callable[[], AnimalAIGymnasiumWrapper]]:
     """Build ``num_envs`` zero-argument env factories ("thunks").
 
@@ -72,6 +79,21 @@ def make_animalai_env_fns(
     wrapper_kwargs : dict, optional
         Extra keyword arguments forwarded to every ``AnimalAIGymnasiumWrapper``
         (e.g. the ``include_*`` observation-stream flags).
+    serialize_launch : bool
+        When ``True`` (default), each thunk acquires a cross-process file lock
+        while it constructs its environment, so only one Unity instance goes
+        through the launch-and-handshake at a time. This prevents concurrent
+        launches (notably under ``async`` on Windows) from contending and
+        exceeding the handshake timeout. The lock is released once the
+        environment has connected, so stepping still runs fully in parallel.
+        Set to ``False`` to launch all environments simultaneously.
+    launch_lock_timeout : float
+        Seconds to wait to acquire the launch lock before raising, guarding
+        against a hung launch blocking the rest of the batch indefinitely.
+    launch_lock_path : str, optional
+        Path of the lock file shared by this batch's thunks. Defaults to
+        ``<tempdir>/animalai_launch_<base_port>.lock``; keying on ``base_port``
+        lets independent vector envs launch without blocking each other.
     """
     if num_envs < 1:
         raise ValueError(f"num_envs must be >= 1, got {num_envs}.")
@@ -88,16 +110,27 @@ def make_animalai_env_fns(
 
     arena_configs = _resolve_arena_configs(arenas_configurations, num_envs)
 
+    if serialize_launch and launch_lock_path is None:
+        launch_lock_path = os.path.join(
+            tempfile.gettempdir(), f"animalai_launch_{base_port}.lock"
+        )
+
     def _make_thunk(index: int) -> Callable[[], AnimalAIGymnasiumWrapper]:
         def _thunk() -> AnimalAIGymnasiumWrapper:
-            env = AnimalAIEnvironment(
-                worker_id=worker_id_start + index,
-                base_port=base_port,
-                seed=seed + index,
-                arenas_configurations=arena_configs[index],
-                **env_kwargs,
+            launch_guard = (
+                FileLock(launch_lock_path, timeout=launch_lock_timeout)
+                if serialize_launch
+                else nullcontext()
             )
-            return AnimalAIGymnasiumWrapper(env, **wrapper_kwargs)
+            with launch_guard:
+                env = AnimalAIEnvironment(
+                    worker_id=worker_id_start + index,
+                    base_port=base_port,
+                    seed=seed + index,
+                    arenas_configurations=arena_configs[index],
+                    **env_kwargs,
+                )
+                return AnimalAIGymnasiumWrapper(env, **wrapper_kwargs)
 
         return _thunk
 
@@ -126,7 +159,8 @@ def make_animalai_vec_env(
     **kwargs
         Forwarded to :func:`make_animalai_env_fns` (``worker_id_start``,
         ``base_port``, ``seed``, ``arenas_configurations``, ``env_kwargs``,
-        ``wrapper_kwargs``).
+        ``wrapper_kwargs``, ``serialize_launch``, ``launch_lock_timeout``,
+        ``launch_lock_path``).
     """
     if vectorization_mode not in ("sync", "async"):
         raise ValueError(

--- a/animalai/wrappers/vector.py
+++ b/animalai/wrappers/vector.py
@@ -1,0 +1,153 @@
+"""Factory helpers for running several Animal-AI environments in parallel.
+
+Animal-AI already supports many simultaneous Unity instances: each
+``AnimalAIEnvironment`` forwards ``worker_id`` to the underlying
+``UnityEnvironment`` and binds to port ``base_port + worker_id`` as its own OS
+process. The gymnasium wrapper, however, is strictly single-environment. These
+helpers bridge the gap by building N ``AnimalAIEnvironment`` + wrapper pairs --
+each with a unique ``worker_id`` (and ``seed``) so ports do not collide -- and
+composing them with Gymnasium's built-in vector envs.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+try:
+    import gymnasium
+except ImportError as exc:
+    raise ImportError(
+        "The gymnasium wrappers require the optional 'gym' extra. "
+        "Install it with: pip install animalai[gym]"
+    ) from exc
+
+from animalai.environment import AnimalAIEnvironment
+from animalai.wrappers.animalai_gymnasium import AnimalAIGymnasiumWrapper
+
+# Owned by the factory; supplying them via env_kwargs would clash with the
+# per-environment values the factory assigns.
+_RESERVED_ENV_KWARGS = ("worker_id", "base_port", "seed", "arenas_configurations")
+
+ArenaConfig = Union[str, Sequence[str]]
+
+
+def make_animalai_env_fns(
+    num_envs: int,
+    *,
+    worker_id_start: int = 0,
+    base_port: int = 5005,
+    seed: int = 0,
+    arenas_configurations: ArenaConfig = "",
+    env_kwargs: Optional[Dict[str, Any]] = None,
+    wrapper_kwargs: Optional[Dict[str, Any]] = None,
+) -> List[Callable[[], AnimalAIGymnasiumWrapper]]:
+    """Build ``num_envs`` zero-argument env factories ("thunks").
+
+    Each thunk constructs an ``AnimalAIEnvironment`` with a unique
+    ``worker_id`` (``worker_id_start + i``) and ``seed`` (``seed + i``), then
+    wraps it in an :class:`AnimalAIGymnasiumWrapper`. The thunks are lazy:
+    nothing launches Unity until a thunk is called, which is what lets a vector
+    env decide when (and, for async, in which process) to construct each env.
+
+    Parameters
+    ----------
+    num_envs : int
+        Number of environments / thunks to create. Must be >= 1.
+    worker_id_start : int
+        ``worker_id`` of the first environment; subsequent envs increment from
+        it. Set this to avoid colliding with other Animal-AI instances already
+        running against the same ``base_port``.
+    base_port : int
+        Base port shared by all environments. Each env's actual port is
+        ``base_port + worker_id``.
+    seed : int
+        Seed of the first environment; subsequent envs increment from it so
+        rollouts differ across the batch.
+    arenas_configurations : str | Sequence[str]
+        Either a single arena YAML path shared by every environment, or a
+        sequence of length ``num_envs`` giving one config per environment.
+    env_kwargs : dict, optional
+        Extra keyword arguments forwarded to every ``AnimalAIEnvironment``
+        (e.g. ``file_name``, ``useCamera``, ``useRayCasts``, ``no_graphics``,
+        ``timescale``). Must not contain any of ``worker_id``, ``base_port``,
+        ``seed`` or ``arenas_configurations`` -- those are owned by the factory.
+    wrapper_kwargs : dict, optional
+        Extra keyword arguments forwarded to every ``AnimalAIGymnasiumWrapper``
+        (e.g. the ``include_*`` observation-stream flags).
+    """
+    if num_envs < 1:
+        raise ValueError(f"num_envs must be >= 1, got {num_envs}.")
+
+    env_kwargs = dict(env_kwargs or {})
+    wrapper_kwargs = dict(wrapper_kwargs or {})
+
+    reserved = [key for key in _RESERVED_ENV_KWARGS if key in env_kwargs]
+    if reserved:
+        raise ValueError(
+            "env_kwargs must not contain factory-owned keys "
+            f"{reserved}; pass them as arguments to make_animalai_env_fns instead."
+        )
+
+    arena_configs = _resolve_arena_configs(arenas_configurations, num_envs)
+
+    def _make_thunk(index: int) -> Callable[[], AnimalAIGymnasiumWrapper]:
+        def _thunk() -> AnimalAIGymnasiumWrapper:
+            env = AnimalAIEnvironment(
+                worker_id=worker_id_start + index,
+                base_port=base_port,
+                seed=seed + index,
+                arenas_configurations=arena_configs[index],
+                **env_kwargs,
+            )
+            return AnimalAIGymnasiumWrapper(env, **wrapper_kwargs)
+
+        return _thunk
+
+    return [_make_thunk(i) for i in range(num_envs)]
+
+
+def make_animalai_vec_env(
+    num_envs: int,
+    *,
+    vectorization_mode: str = "sync",
+    **kwargs: Any,
+) -> "gymnasium.vector.VectorEnv":
+    """Build a Gymnasium vector env wrapping ``num_envs`` Animal-AI envs.
+
+    A thin convenience over :func:`make_animalai_env_fns`: it builds the thunks
+    and hands them to Gymnasium's vector machinery.
+
+    Parameters
+    ----------
+    num_envs : int
+        Number of environments to run in parallel.
+    vectorization_mode : {"sync", "async"}
+        ``"sync"`` (default) steps the environments sequentially in this process
+        via ``SyncVectorEnv``. ``"async"`` runs each environment in its own
+        subprocess via ``AsyncVectorEnv`` for step-time parallelism.
+    **kwargs
+        Forwarded to :func:`make_animalai_env_fns` (``worker_id_start``,
+        ``base_port``, ``seed``, ``arenas_configurations``, ``env_kwargs``,
+        ``wrapper_kwargs``).
+    """
+    if vectorization_mode not in ("sync", "async"):
+        raise ValueError(
+            f"vectorization_mode must be 'sync' or 'async', got {vectorization_mode!r}."
+        )
+
+    env_fns = make_animalai_env_fns(num_envs, **kwargs)
+
+    if vectorization_mode == "async":
+        return gymnasium.vector.AsyncVectorEnv(env_fns)
+    return gymnasium.vector.SyncVectorEnv(env_fns)
+
+
+def _resolve_arena_configs(arenas_configurations: ArenaConfig, num_envs: int) -> List[str]:
+    if isinstance(arenas_configurations, str):
+        return [arenas_configurations] * num_envs
+
+    configs = list(arenas_configurations)
+    if len(configs) != num_envs:
+        raise ValueError(
+            f"arenas_configurations has {len(configs)} entries but num_envs is "
+            f"{num_envs}; pass a single string or one config per environment."
+        )
+    return configs

--- a/animalai/wrappers/vector.py
+++ b/animalai/wrappers/vector.py
@@ -140,7 +140,7 @@ def make_animalai_env_fns(
 def make_animalai_vec_env(
     num_envs: int,
     *,
-    vectorization_mode: str = "sync",
+    vectorization_mode: str = "async",
     **kwargs: Any,
 ) -> "gymnasium.vector.VectorEnv":
     """Build a Gymnasium vector env wrapping ``num_envs`` Animal-AI envs.
@@ -153,8 +153,8 @@ def make_animalai_vec_env(
     num_envs : int
         Number of environments to run in parallel.
     vectorization_mode : {"sync", "async"}
-        ``"sync"`` (default) steps the environments sequentially in this process
-        via ``SyncVectorEnv``. ``"async"`` runs each environment in its own
+        ``"sync"`` steps the environments sequentially in this process
+        via ``SyncVectorEnv``. ``"async"`` (default) runs each environment in its own
         subprocess via ``AsyncVectorEnv`` for step-time parallelism.
     **kwargs
         Forwarded to :func:`make_animalai_env_fns` (``worker_id_start``,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ inspect-ai = [
 ]
 gymnasium = [
     "gymnasium>=1.0",
+    "filelock",
 ]
 
 [project.urls]

--- a/tests/wrappers/test_animalai_vector.py
+++ b/tests/wrappers/test_animalai_vector.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import gymnasium
@@ -211,6 +211,11 @@ class TestEnvFns(_VectorTestCase):
         self.assertIsInstance(wrapper.observation_space, spaces.Box)
         self.assertEqual(wrapper.observation_space.shape, (6,))
 
+    def test_timeout_wait_forwarded(self):
+        fns = vector.make_animalai_env_fns(1, env_kwargs={"timeout_wait": 120})
+        env = fns[0]()._env
+        self.assertEqual(env.extra.get("timeout_wait"), 120)
+
     def test_reserved_keys_in_env_kwargs_raise(self):
         for key in ("worker_id", "base_port", "seed", "arenas_configurations"):
             with self.assertRaises(ValueError):
@@ -255,6 +260,92 @@ class TestVecEnv(_VectorTestCase):
         envs = list(_FakeAAIEnv.instances)
         venv.close()
         self.assertTrue(all(e.closed for e in envs))
+
+
+# ---------------------------------------------------------------------------
+# Launch serialization: cross-process file lock around env construction
+# ---------------------------------------------------------------------------
+
+class _SpyLock:
+    """Stand-in for filelock.FileLock that records its lifecycle.
+
+    events interleaves lock enter/exit with env construction so a test can
+    assert the env is built *while the lock is held*. calls records the
+    (path, timeout) each FileLock was constructed with.
+    """
+
+    events: list = []
+    calls: list = []
+
+    def __init__(self, path, timeout=-1):
+        _SpyLock.calls.append((str(path), timeout))
+        self._path = str(path)
+
+    def __enter__(self):
+        _SpyLock.events.append(("enter", self._path))
+        return self
+
+    def __exit__(self, *exc):
+        _SpyLock.events.append(("exit", self._path))
+        return False
+
+
+class _LoggingFakeEnv(_FakeAAIEnv):
+    """A fake env that marks the moment of its construction on _SpyLock.events."""
+
+    def __init__(self, **kwargs):
+        _SpyLock.events.append(("construct", None))
+        super().__init__(**kwargs)
+
+
+class TestLaunchLock(_VectorTestCase):
+    def setUp(self):
+        super().setUp()
+        _SpyLock.events = []
+        _SpyLock.calls = []
+
+    def test_lock_held_around_construction(self):
+        vector.AnimalAIEnvironment = _LoggingFakeEnv
+        with patch.object(vector, "FileLock", _SpyLock):
+            fn = vector.make_animalai_env_fns(1, env_kwargs={"useCamera": False})[0]
+            fn()
+        self.assertEqual(
+            [kind for kind, _ in _SpyLock.events],
+            ["enter", "construct", "exit"],
+        )
+
+    def test_lock_path_keyed_on_base_port(self):
+        with patch.object(vector, "FileLock", _SpyLock):
+            vector.make_animalai_env_fns(1, base_port=6123)[0]()
+        self.assertEqual(len(_SpyLock.calls), 1)
+        path, _ = _SpyLock.calls[0]
+        self.assertIn("animalai_launch_6123", path)
+
+    def test_lock_timeout_forwarded(self):
+        with patch.object(vector, "FileLock", _SpyLock):
+            vector.make_animalai_env_fns(1, launch_lock_timeout=42.0)[0]()
+        self.assertEqual(_SpyLock.calls[0][1], 42.0)
+
+    def test_shared_path_across_thunks(self):
+        with patch.object(vector, "FileLock", _SpyLock):
+            for fn in vector.make_animalai_env_fns(3, base_port=7000):
+                fn()
+        paths = {path for path, _ in _SpyLock.calls}
+        self.assertEqual(len(paths), 1)
+
+    def test_custom_lock_path(self):
+        with patch.object(vector, "FileLock", _SpyLock):
+            vector.make_animalai_env_fns(
+                1, launch_lock_path="/tmp/my.lock"
+            )[0]()
+        self.assertEqual(_SpyLock.calls[0][0], "/tmp/my.lock")
+
+    def test_opt_out_skips_lock(self):
+        with patch.object(vector, "FileLock", _SpyLock):
+            vector.make_animalai_env_fns(1, serialize_launch=False)[0]()
+        self.assertEqual(_SpyLock.calls, [])
+        # Env is still built without the lock.
+        self.assertEqual(len(_FakeAAIEnv.instances), 1)
 
 
 if __name__ == "__main__":

--- a/tests/wrappers/test_animalai_vector.py
+++ b/tests/wrappers/test_animalai_vector.py
@@ -1,0 +1,261 @@
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import gymnasium
+from gymnasium import spaces
+
+from animalai.environment import AnimalAIEnvironment
+from animalai.wrappers import vector
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _ObsSpec:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _ActionSpec:
+    discrete_branches = (3, 3)
+    continuous_size = 0
+
+    @property
+    def discrete_size(self):
+        return len(self.discrete_branches)
+
+    def is_discrete(self):
+        return True
+
+    def is_continuous(self):
+        return False
+
+
+class _BehaviorSpec:
+    def __init__(self, observation_specs):
+        self.observation_specs = observation_specs
+        self.action_spec = _ActionSpec()
+
+
+class _Steps:
+    def __init__(self, obs, reward, n=1, interrupted=None):
+        self.obs = obs
+        self.reward = reward
+        self._n = n
+        if interrupted is not None:
+            self.interrupted = interrupted
+
+    def __len__(self):
+        return self._n
+
+
+def _camera_batch(h=4, w=4, c=3, val=0.5):
+    return np.full((1, h, w, c), val, dtype=np.float32)
+
+
+def _vector_batch():
+    return np.array([[5.0, 1.0, 2.0, 3.0, 7.0, 8.0, 9.0]], dtype=np.float32)
+
+
+def _rays_batch(length=6, val=0.3):
+    return np.full((1, length), val, dtype=np.float32)
+
+
+class _FakeAAIEnv(AnimalAIEnvironment):
+    """An AnimalAIEnvironment that records its construction kwargs and skips the
+    real Unity launch.
+
+    Its __init__ mirrors the keyword arguments the factory passes through
+    (worker_id / base_port / seed / arenas_configurations plus any env_kwargs),
+    so tests can assert how the factory assigned them. Subclassing the real
+    class satisfies the wrapper's isinstance check.
+    """
+
+    # Records every instance built during a test so assertions can inspect them.
+    instances: list = []
+
+    def __init__(
+        self,
+        *,
+        worker_id=0,
+        base_port=5005,
+        seed=0,
+        arenas_configurations="",
+        useCamera=True,
+        useRayCasts=False,
+        **extra,
+    ):
+        self.worker_id = worker_id
+        self.base_port = base_port
+        self.seed_value = seed
+        self.arenas_configurations = arenas_configurations
+        self.extra = extra
+        self.useCamera = useCamera
+        self.useRayCasts = useRayCasts
+        self.obsdict = {
+            "camera": [],
+            "rays": [],
+            "health": [],
+            "velocity": [],
+            "position": [],
+        }
+
+        specs = []
+        obs = []
+        if useCamera:
+            specs.append(_ObsSpec((4, 4, 3)))
+            obs.append(_camera_batch())
+        if useRayCasts:
+            specs.append(_ObsSpec((6,)))
+            obs.append(_rays_batch())
+        specs.append(_ObsSpec((7,)))
+        obs.append(_vector_batch())
+        self._specs = {"Brain?team=0": _BehaviorSpec(specs)}
+        self._decision = _Steps(obs=obs, reward=[0.0], n=1)
+        self._terminal = _Steps(obs=[], reward=[], n=0)
+
+        self.set_actions = MagicMock()
+        self.step = MagicMock()
+        self.reset = MagicMock()
+        self.closed = False
+        _FakeAAIEnv.instances.append(self)
+
+    @property
+    def behavior_specs(self):
+        return self._specs
+
+    def get_steps(self, name):
+        return self._decision, self._terminal
+
+    def close(self):
+        self.closed = True
+
+
+class _VectorTestCase(unittest.TestCase):
+    def setUp(self):
+        _FakeAAIEnv.instances = []
+        # The factory constructs AnimalAIEnvironment by name; swap in the fake.
+        self._real_env = vector.AnimalAIEnvironment
+        vector.AnimalAIEnvironment = _FakeAAIEnv
+
+    def tearDown(self):
+        vector.AnimalAIEnvironment = self._real_env
+
+
+# ---------------------------------------------------------------------------
+# Thunk construction: make_animalai_env_fns
+# ---------------------------------------------------------------------------
+
+class TestEnvFns(_VectorTestCase):
+    def test_returns_num_envs_callables(self):
+        fns = vector.make_animalai_env_fns(3)
+        self.assertEqual(len(fns), 3)
+        self.assertTrue(all(callable(fn) for fn in fns))
+        # Thunks are lazy: nothing built until called.
+        self.assertEqual(_FakeAAIEnv.instances, [])
+
+    def test_unique_worker_ids_and_seeds(self):
+        fns = vector.make_animalai_env_fns(3, worker_id_start=10, seed=100)
+        wrappers = [fn() for fn in fns]
+        self.assertEqual(len(wrappers), 3)
+        worker_ids = [w._env.worker_id for w in wrappers]
+        seeds = [w._env.seed_value for w in wrappers]
+        self.assertEqual(worker_ids, [10, 11, 12])
+        self.assertEqual(seeds, [100, 101, 102])
+
+    def test_base_port_shared(self):
+        fns = vector.make_animalai_env_fns(2, base_port=6000)
+        envs = [fn()._env for fn in fns]
+        self.assertEqual([e.base_port for e in envs], [6000, 6000])
+
+    def test_single_arena_config_shared(self):
+        fns = vector.make_animalai_env_fns(2, arenas_configurations="a.yml")
+        envs = [fn()._env for fn in fns]
+        self.assertEqual([e.arenas_configurations for e in envs], ["a.yml", "a.yml"])
+
+    def test_per_env_arena_config_list(self):
+        fns = vector.make_animalai_env_fns(
+            2, arenas_configurations=["a.yml", "b.yml"]
+        )
+        envs = [fn()._env for fn in fns]
+        self.assertEqual([e.arenas_configurations for e in envs], ["a.yml", "b.yml"])
+
+    def test_wrong_length_arena_list_raises(self):
+        with self.assertRaises(ValueError):
+            vector.make_animalai_env_fns(3, arenas_configurations=["a.yml", "b.yml"])
+
+    def test_env_kwargs_forwarded(self):
+        fns = vector.make_animalai_env_fns(
+            1, env_kwargs={"useRayCasts": True, "no_graphics": True}
+        )
+        env = fns[0]()._env
+        self.assertTrue(env.useRayCasts)
+        self.assertEqual(env.extra.get("no_graphics"), True)
+
+    def test_wrapper_kwargs_forwarded(self):
+        fns = vector.make_animalai_env_fns(
+            1,
+            env_kwargs={"useRayCasts": True},
+            wrapper_kwargs={
+                "include_rays": True,
+                "include_camera": False,
+                "include_health": False,
+                "include_velocity": False,
+                "include_position": False,
+            },
+        )
+        wrapper = fns[0]()
+        # A single selected stream collapses to a bare Box.
+        self.assertIsInstance(wrapper.observation_space, spaces.Box)
+        self.assertEqual(wrapper.observation_space.shape, (6,))
+
+    def test_reserved_keys_in_env_kwargs_raise(self):
+        for key in ("worker_id", "base_port", "seed", "arenas_configurations"):
+            with self.assertRaises(ValueError):
+                vector.make_animalai_env_fns(1, env_kwargs={key: 1})
+
+    def test_invalid_num_envs_raises(self):
+        with self.assertRaises(ValueError):
+            vector.make_animalai_env_fns(0)
+
+
+# ---------------------------------------------------------------------------
+# Vector env assembly: make_animalai_vec_env
+# ---------------------------------------------------------------------------
+
+class TestVecEnv(_VectorTestCase):
+    def _make(self, num_envs=2, **kwargs):
+        kwargs.setdefault("env_kwargs", {"useCamera": False})
+        return vector.make_animalai_vec_env(num_envs, **kwargs)
+
+    def test_returns_sync_vector_env(self):
+        venv = self._make(2)
+        self.assertIsInstance(venv, gymnasium.vector.SyncVectorEnv)
+        self.assertEqual(venv.num_envs, 2)
+        venv.close()
+
+    def test_async_mode_selects_async_env(self):
+        # Only assert the mode is validated/dispatched; do not spin up
+        # subprocesses in the unit test.
+        with self.assertRaises(ValueError):
+            self._make(2, vectorization_mode="not-a-mode")
+
+    def test_reset_returns_batched_obs(self):
+        venv = self._make(2)
+        obs, info = venv.reset()
+        self.assertEqual(set(obs), {"health", "velocity", "position"})
+        self.assertEqual(obs["velocity"].shape, (2, 3))
+        self.assertEqual(obs["position"].shape, (2, 3))
+        venv.close()
+
+    def test_close_propagates(self):
+        venv = self._make(2)
+        envs = list(_FakeAAIEnv.instances)
+        venv.close()
+        self.assertTrue(all(e.closed for e in envs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Description

it can be kind of complicated to setup multiple animalai environments as a single vectorised environment in gymnasium. The purpose of this PR is so add helper methods to make it simple and consistent to run multiple environments for faster training of RL models.

### Proposed change(s)

Added `make_animalai_vec_env` helper method which creates a collection of AnimalAi environments wrapped with the `UnityToGymnasium` wrapper and combined into a singe vectorised environment.

### Useful links (Github issues, discussion threads, etc.)

[link to doc change PR](https://github.com/Kinds-of-Intelligence-CFI/animal-ai/pull/66)

### Types of change(s)
- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the changelog (if applicable)
- [ ] Updated the documentation (if applicable)
- [ ] Updated the migration guide (if applicable)

### Other comments (if any)

### Screenshots (if any)
